### PR TITLE
remove cabal key while removing cabal

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -197,7 +197,7 @@ class Client {
     details._destroy()
 
     // burn everything we know about the cabal
-    this._keyToCabal[key] = null
+    delete this._keyToCabal[key]
     return this.cabals.delete(cabal)
   }
 


### PR DESCRIPTION
since key wasnt removed `getCabalKeys` would still return the key.