### PR TITLE
Add modular event listeners

### DIFF
--- a/api.md
+++ b/api.md
@@ -50,7 +50,7 @@
 <a name="new_Client_new"></a>
 
 ### new Client([opts])
-Create a client instance from which to manage multiple
+Create a client instance from which to manage multiple 
 [`cabal-core`](https://github.com/cabal-club/cabal-core/) instances.
 
 **Params**
@@ -435,6 +435,7 @@ Returns a string path of where all of the cabals are stored on the hard drive.
     * [.joinChannel(channel)](#CabalDetails+joinChannel)
     * [.leaveChannel(channel)](#CabalDetails+leaveChannel)
     * [.getUsers()](#CabalDetails+getUsers) ⇒ <code>object</code>
+    * [._emitUpdate()](#CabalDetails+_emitUpdate)
     * [._destroy()](#CabalDetails+_destroy)
     * ["update"](#CabalDetails+event_update)
 
@@ -629,6 +630,33 @@ that you have left the channel.
 ### cabalDetails.getUsers() ⇒ <code>object</code>
 **Returns**: <code>object</code> - all of the users in this cabal. Each key is the public key of its 
 corresponding user.  
+
+* * *
+
+<a name="CabalDetails+_emitUpdate"></a>
+
+### cabalDetails.\_emitUpdate()
+Emits event updates with different types and corresponding payloads. Listen for these events to update state.
+
+**Example**  
+```js
+events and payloads are documented as `<type>`: `<payload>|empty`:
+`init`: empty
+`user-updated`: `{ key, user }`
+`new-channel`: `{ channel }`
+`new-message`: `{ channel, author: { name, key, local, online }, message }` note: includes chat/topic, chat/emote, chat/text
+`publish-message`: `{ message, timestamp }`
+`publish-nick`: `{ name }`
+`status-message`: `{ channel, message }`
+`topic`: `{ channel, topic }`
+`channel-focus`: `{ channel }`
+`channel-join`: `{ key, channel, isLocal }`
+`channel-leave`: `{ key, channel, isLocal }`
+`cabal-focus`: `{ cabalkey }`
+`started-peering`: { key, name }`
+`stoppped-peering`: { key, name }`
+`update`: empty - generic update from previous iteration, signals that something changed
+```
 
 * * *
 

--- a/api.md
+++ b/api.md
@@ -415,7 +415,7 @@ Returns a string path of where all of the cabals are stored on the hard drive.
 <a name="CabalDetails"></a>
 
 ## CabalDetails
-**Emits**: [<code>update</code>](#CabalDetails+event_update), [<code>init</code>](#CabalDetails+event_init), [<code>user-updated</code>](#CabalDetails+event_user-updated), [<code>new-channel</code>](#CabalDetails+event_new-channel), [<code>new-message</code>](#CabalDetails+event_new-message), <code>CabalDetails#event:publish-message</code>, [<code>publish-nick</code>](#CabalDetails+event_publish-nick), [<code>status-message</code>](#CabalDetails+event_status-message), [<code>topic</code>](#CabalDetails+event_topic), [<code>channel-focus</code>](#CabalDetails+event_channel-focus), [<code>channel-join</code>](#CabalDetails+event_channel-join), [<code>channel-leave</code>](#CabalDetails+event_channel-leave), [<code>cabal-focus</code>](#CabalDetails+event_cabal-focus), [<code>started-peering</code>](#CabalDetails+event_started-peering), <code>CabalDetails#event:stoppped-peering</code>, [<code>update</code>](#CabalDetails+event_update)  
+**Emits**: [<code>update</code>](#CabalDetails+event_update), [<code>init</code>](#CabalDetails+event_init), [<code>user-updated</code>](#CabalDetails+event_user-updated), [<code>new-channel</code>](#CabalDetails+event_new-channel), [<code>new-message</code>](#CabalDetails+event_new-message), [<code>publish-message</code>](#CabalDetails+event_publish-message), [<code>publish-nick</code>](#CabalDetails+event_publish-nick), [<code>status-message</code>](#CabalDetails+event_status-message), [<code>topic</code>](#CabalDetails+event_topic), [<code>channel-focus</code>](#CabalDetails+event_channel-focus), [<code>channel-join</code>](#CabalDetails+event_channel-join), [<code>channel-leave</code>](#CabalDetails+event_channel-leave), [<code>cabal-focus</code>](#CabalDetails+event_cabal-focus), [<code>started-peering</code>](#CabalDetails+event_started-peering), [<code>stopped-peering</code>](#CabalDetails+event_stopped-peering)  
 
 * [CabalDetails](#CabalDetails)
     * [new CabalDetails(cabal, done)](#new_CabalDetails_new)
@@ -441,6 +441,7 @@ Returns a string path of where all of the cabals are stored on the hard drive.
     * ["user-updated"](#CabalDetails+event_user-updated)
     * ["new-channel"](#CabalDetails+event_new-channel)
     * ["new-message"](#CabalDetails+event_new-message)
+    * ["publish-message"](#CabalDetails+event_publish-message)
     * ["publish-nick"](#CabalDetails+event_publish-nick)
     * ["status-message"](#CabalDetails+event_status-message)
     * ["topic"](#CabalDetails+event_topic)
@@ -727,11 +728,28 @@ Fires when a new message has been posted
 | author.key | <code>string</code> | Public key of the user |
 | author.local | <code>boolean</code> | True if user is the local user (i.e. at the keyboard and not someone else in the cabal) |
 | author.online | <code>boolean</code> | True if the user is currently online |
-| message | <code>object</code> | The message that was posted |
+| message | <code>object</code> | The message that was posted. See `cabal-core` for more complete message documentation. |
 | message.key | <code>string</code> | Public key of the user posting the message (again, it's a quirk) |
 | message.seq | <code>number</code> | Sequence number of the message in the user's append-only log |
 | message.value | <code>object</code> | Message content, see `cabal-core` documentation for more information. |
-| message.directMention | <code>object</code> | True if the message contained a direct mention |
+
+
+* * *
+
+<a name="CabalDetails+event_publish-message"></a>
+
+### "publish-message"
+Fires when the local user has published a new message
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| message | <code>object</code> | The message that was posted. See `cabal-core` for more complete message documentation. |
+| message.type | <code>string</code> | Message type that was posted, e.g. `chat/text` or `chat/emote` |
+| message.content | <code>string</code> | Message contents, e.g. channel and text if `chat/text` |
+| message.timestamp | <code>number</code> | The time the message was published |
 
 
 * * *

--- a/api.md
+++ b/api.md
@@ -415,7 +415,7 @@ Returns a string path of where all of the cabals are stored on the hard drive.
 <a name="CabalDetails"></a>
 
 ## CabalDetails
-**Emits**: [<code>update</code>](#CabalDetails+event_update)  
+**Emits**: [<code>update</code>](#CabalDetails+event_update), [<code>init</code>](#CabalDetails+event_init), [<code>user-updated</code>](#CabalDetails+event_user-updated), [<code>new-channel</code>](#CabalDetails+event_new-channel), [<code>new-message</code>](#CabalDetails+event_new-message), <code>CabalDetails#event:publish-message</code>, [<code>publish-nick</code>](#CabalDetails+event_publish-nick), [<code>status-message</code>](#CabalDetails+event_status-message), [<code>topic</code>](#CabalDetails+event_topic), [<code>channel-focus</code>](#CabalDetails+event_channel-focus), [<code>channel-join</code>](#CabalDetails+event_channel-join), [<code>channel-leave</code>](#CabalDetails+event_channel-leave), [<code>cabal-focus</code>](#CabalDetails+event_cabal-focus), [<code>started-peering</code>](#CabalDetails+event_started-peering), <code>CabalDetails#event:stoppped-peering</code>, [<code>update</code>](#CabalDetails+event_update)  
 
 * [CabalDetails](#CabalDetails)
     * [new CabalDetails(cabal, done)](#new_CabalDetails_new)
@@ -435,8 +435,21 @@ Returns a string path of where all of the cabals are stored on the hard drive.
     * [.joinChannel(channel)](#CabalDetails+joinChannel)
     * [.leaveChannel(channel)](#CabalDetails+leaveChannel)
     * [.getUsers()](#CabalDetails+getUsers) ⇒ <code>object</code>
-    * [._emitUpdate()](#CabalDetails+_emitUpdate)
     * [._destroy()](#CabalDetails+_destroy)
+    * ["update"](#CabalDetails+event_update)
+    * ["init"](#CabalDetails+event_init)
+    * ["user-updated"](#CabalDetails+event_user-updated)
+    * ["new-channel"](#CabalDetails+event_new-channel)
+    * ["new-message"](#CabalDetails+event_new-message)
+    * ["publish-nick"](#CabalDetails+event_publish-nick)
+    * ["status-message"](#CabalDetails+event_status-message)
+    * ["topic"](#CabalDetails+event_topic)
+    * ["channel-focus"](#CabalDetails+event_channel-focus)
+    * ["channel-join"](#CabalDetails+event_channel-join)
+    * ["channel-leave"](#CabalDetails+event_channel-leave)
+    * ["cabal-focus"](#CabalDetails+event_cabal-focus)
+    * ["started-peering"](#CabalDetails+event_started-peering)
+    * ["stopped-peering"](#CabalDetails+event_stopped-peering)
     * ["update"](#CabalDetails+event_update)
 
 
@@ -633,33 +646,6 @@ corresponding user.
 
 * * *
 
-<a name="CabalDetails+_emitUpdate"></a>
-
-### cabalDetails.\_emitUpdate()
-Emits event updates with different types and corresponding payloads. Listen for these events to update state.
-
-**Example**  
-```js
-events and payloads are documented as `<type>`: `<payload>|empty`:
-`init`: empty
-`user-updated`: `{ key, user }`
-`new-channel`: `{ channel }`
-`new-message`: `{ channel, author: { name, key, local, online }, message }` note: includes chat/topic, chat/emote, chat/text
-`publish-message`: `{ message, timestamp }`
-`publish-nick`: `{ name }`
-`status-message`: `{ channel, message }`
-`topic`: `{ channel, topic }`
-`channel-focus`: `{ channel }`
-`channel-join`: `{ key, channel, isLocal }`
-`channel-leave`: `{ key, channel, isLocal }`
-`cabal-focus`: `{ cabalkey }`
-`started-peering`: { key, name }`
-`stoppped-peering`: { key, name }`
-`update`: empty - generic update from previous iteration, signals that something changed
-```
-
-* * *
-
 <a name="CabalDetails+_destroy"></a>
 
 ### cabalDetails.\_destroy()
@@ -681,6 +667,226 @@ Destroy all of the listeners associated with this `details` instance
 | name | <code>string</code> | The user's username |
 | key | <code>string</code> | The user's public key |
 
+
+* * *
+
+<a name="CabalDetails+event_init"></a>
+
+### "init"
+Fires when the cabal has finished initialization
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+
+* * *
+
+<a name="CabalDetails+event_user-updated"></a>
+
+### "user-updated"
+Fires when a user has updated their nickname
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | Public key of the updated user |
+| user | <code>object</code> | Object containing user information |
+| user.name | <code>string</code> | Current nickname of the updated user |
+
+
+* * *
+
+<a name="CabalDetails+event_new-channel"></a>
+
+### "new-channel"
+Fires when a new channel has been created
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the created channel |
+
+
+* * *
+
+<a name="CabalDetails+event_new-message"></a>
+
+### "new-message"
+Fires when a new message has been posted
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the channel the message was posted to |
+| author | <code>object</code> | Object containing the user that posted the message |
+| author.name | <code>string</code> | Nickname of the user |
+| author.key | <code>string</code> | Public key of the user |
+| author.local | <code>boolean</code> | True if user is the local user (i.e. at the keyboard and not someone else in the cabal) |
+| author.online | <code>boolean</code> | True if the user is currently online |
+| message | <code>object</code> | The message that was posted |
+| message.key | <code>string</code> | Public key of the user posting the message (again, it's a quirk) |
+| message.seq | <code>number</code> | Sequence number of the message in the user's append-only log |
+| message.value | <code>object</code> | Message content, see `cabal-core` documentation for more information. |
+| message.directMention | <code>object</code> | True if the message contained a direct mention |
+
+
+* * *
+
+<a name="CabalDetails+event_publish-nick"></a>
+
+### "publish-nick"
+Fires when the local user has published a new nickname
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | The nickname that was published |
+
+
+* * *
+
+<a name="CabalDetails+event_status-message"></a>
+
+### "status-message"
+Fires when a status message has been created. These are only visible by the local user.
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the channel the message was published to |
+| message | <code>object</code> |  |
+| message.timestamp | <code>number</code> | Publish timestamp |
+| message.text | <code>string</code> | The published status message contents |
+
+
+* * *
+
+<a name="CabalDetails+event_topic"></a>
+
+### "topic"
+Fires when a new channel topic has been set
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the channel with the new topic |
+| topic | <code>string</code> | Name of the channel with the new topic |
+
+
+* * *
+
+<a name="CabalDetails+event_channel-focus"></a>
+
+### "channel-focus"
+Fires when the user has focused (i.e. switched to) a new channel
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the focused channel |
+
+
+* * *
+
+<a name="CabalDetails+event_channel-join"></a>
+
+### "channel-join"
+Fires when a user has joined a channel
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the joined channel |
+| key | <code>string</code> | Public key of the user joining the channel |
+| isLocal | <code>boolean</code> | True if it was the local user joining a new channel |
+
+
+* * *
+
+<a name="CabalDetails+event_channel-leave"></a>
+
+### "channel-leave"
+Fires when a user has leaveed a channel
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| channel | <code>string</code> | Name of the leaved channel |
+| key | <code>string</code> | Public key of the user leaving the channel |
+| isLocal | <code>boolean</code> | True if it was the local user leaving a new channel |
+
+
+* * *
+
+<a name="CabalDetails+event_cabal-focus"></a>
+
+### "cabal-focus"
+Fires when another cabal has been focused
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | Key of the focused cabal |
+
+
+* * *
+
+<a name="CabalDetails+event_started-peering"></a>
+
+### "started-peering"
+Fires when the local user has connected directly with another peer
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | Public key of the other peer |
+| name- | <code>string</code> | Name of the other peer |
+
+
+* * *
+
+<a name="CabalDetails+event_stopped-peering"></a>
+
+### "stopped-peering"
+Fires when the local user has disconnected with another peer
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | Public key of the other peer |
+| name- | <code>string</code> | Name of the other peer |
+
+
+* * *
+
+<a name="CabalDetails+event_update"></a>
+
+### "update"
+Fires when any kind of change has happened to the cabal.
+
+**Kind**: event emitted by [<code>CabalDetails</code>](#CabalDetails)  
 
 * * *
 

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -345,11 +345,22 @@ class CabalDetails extends EventEmitter {
    * @prop {string} author.key - Public key of the user 
    * @prop {boolean} author.local - True if user is the local user (i.e. at the keyboard and not someone else in the cabal)
    * @prop {boolean} author.online - True if the user is currently online
-   * @prop {object} message - The message that was posted
+   * @prop {object} message - The message that was posted. See `cabal-core` for more complete message documentation.
    * @prop {string} message.key - Public key of the user posting the message (again, it's a quirk)
    * @prop {number} message.seq - Sequence number of the message in the user's append-only log 
    * @prop {object} message.value - Message content, see `cabal-core` documentation for more information.
-   * @prop {object} message.directMention - True if the message contained a direct mention
+   *    
+   */
+
+  /**
+   *
+   * Fires when the local user has published a new message
+   * @event CabalDetails#publish-message
+   * @type {object}
+   * @prop {object} message - The message that was posted. See `cabal-core` for more complete message documentation.
+   * @prop {string} message.type - Message type that was posted, e.g. `chat/text` or `chat/emote` 
+   * @prop {string} message.content - Message contents, e.g. channel and text if `chat/text`
+   * @prop {number} message.timestamp - The time the message was published
    *    
    */
    

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -32,7 +32,6 @@ class CabalDetails extends EventEmitter {
    * @fires CabalDetails#cabal-focus
    * @fires CabalDetails#started-peering
    * @fires CabalDetails#stopped-peering
-   * @fires CabalDetails#update
    * @param {*} cabal 
    * @param {function} done the function to be called after the cabal is initialized
    */

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -31,7 +31,7 @@ class CabalDetails extends EventEmitter {
    * @fires CabalDetails#channel-leave
    * @fires CabalDetails#cabal-focus
    * @fires CabalDetails#started-peering
-   * @fires CabalDetails#stoppped-peering
+   * @fires CabalDetails#stopped-peering
    * @fires CabalDetails#update
    * @param {*} cabal 
    * @param {function} done the function to be called after the cabal is initialized

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -18,6 +18,21 @@ class CabalDetails extends EventEmitter {
    * 
    * @constructor
    * @fires CabalDetails#update
+   * @fires CabalDetails#init
+   * @fires CabalDetails#user-updated
+   * @fires CabalDetails#new-channel
+   * @fires CabalDetails#new-message
+   * @fires CabalDetails#publish-message
+   * @fires CabalDetails#publish-nick
+   * @fires CabalDetails#status-message
+   * @fires CabalDetails#topic
+   * @fires CabalDetails#channel-focus
+   * @fires CabalDetails#channel-join
+   * @fires CabalDetails#channel-leave
+   * @fires CabalDetails#cabal-focus
+   * @fires CabalDetails#started-peering
+   * @fires CabalDetails#stoppped-peering
+   * @fires CabalDetails#update
    * @param {*} cabal 
    * @param {function} done the function to be called after the cabal is initialized
    */
@@ -295,26 +310,138 @@ class CabalDetails extends EventEmitter {
     return Object.assign({}, this.users)
   }
 
-  /** Emits event updates with different types and corresponding payloads. Listen for these events to update state.
-  * @example
-  * events and payloads are documented as `<type>`: `<payload>|empty`:
-  * `init`: empty
-  * `user-updated`: `{ key, user }`
-  * `new-channel`: `{ channel }`
-  * `new-message`: `{ channel, author: { name, key, local, online }, message }` note: includes chat/topic, chat/emote, chat/text
-  * `publish-message`: `{ message, timestamp }`
-  * `publish-nick`: `{ name }`
-  * `status-message`: `{ channel, message }`
-  * `topic`: `{ channel, topic }`
-  * `channel-focus`: `{ channel }`
-  * `channel-join`: `{ key, channel, isLocal }`
-  * `channel-leave`: `{ key, channel, isLocal }`
-  * `cabal-focus`: `{ cabalkey }`
-  * `started-peering`: { key, name }`
-  * `stoppped-peering`: { key, name }`
-  * `update`: empty - generic update from previous iteration, signals that something changed
-  *
-  */
+  /**
+   *
+   * Fires when the cabal has finished initialization
+   * @event CabalDetails#init
+   */
+
+  /**
+   *
+   * Fires when a user has updated their nickname
+   * @event CabalDetails#user-updated
+   * @type {object}
+   * @property {string} key - Public key of the updated user
+   * @property {object} user - Object containing user information 
+   * @prop {string} user.name - Current nickname of the updated user
+   */
+
+  /**
+   *
+   * Fires when a new channel has been created
+   * @event CabalDetails#new-channel
+   * @type {object}
+   * @property {string} channel - Name of the created channel
+   */
+
+  /**
+   *
+   * Fires when a new message has been posted
+   * @event CabalDetails#new-message
+   * @type {object}
+   * @property {string} channel - Name of the channel the message was posted to
+   * @property {object} author - Object containing the user that posted the message
+   * @prop {string} author.name - Nickname of the user 
+   * @prop {string} author.key - Public key of the user 
+   * @prop {boolean} author.local - True if user is the local user (i.e. at the keyboard and not someone else in the cabal)
+   * @prop {boolean} author.online - True if the user is currently online
+   * @prop {object} message - The message that was posted
+   * @prop {string} message.key - Public key of the user posting the message (again, it's a quirk)
+   * @prop {number} message.seq - Sequence number of the message in the user's append-only log 
+   * @prop {object} message.value - Message content, see `cabal-core` documentation for more information.
+   * @prop {object} message.directMention - True if the message contained a direct mention
+   *    
+   */
+   
+  /**
+   *
+   * Fires when the local user has published a new nickname
+   * @event CabalDetails#publish-nick
+   * @type {object}
+   * @property {string} name - The nickname that was published
+   */
+   
+  /**
+   *
+   * Fires when a status message has been created. These are only visible by the local user.
+   * @event CabalDetails#status-message
+   * @type {object}
+   * @property {string} channel - Name of the channel the message was published to 
+   * @prop {object} message
+   * @prop {number} message.timestamp - Publish timestamp
+   * @prop {string} message.text - The published status message contents
+   */
+   
+  /**
+   *
+   * Fires when a new channel topic has been set
+   * @event CabalDetails#topic
+   * @type {object}
+   * @property {string} channel - Name of the channel with the new topic
+   * @property {string} topic - Name of the channel with the new topic
+   */
+
+  /**
+   *
+   * Fires when the user has focused (i.e. switched to) a new channel
+   * @event CabalDetails#channel-focus
+   * @type {object}
+   * @property {string} channel - Name of the focused channel
+   */
+
+  /**
+   *
+   * Fires when a user has joined a channel
+   * @event CabalDetails#channel-join
+   * @type {object}
+   * @property {string} channel - Name of the joined channel
+   * @property {string} key - Public key of the user joining the channel
+   * @property {boolean} isLocal - True if it was the local user joining a new channel
+   */
+
+  /**
+   *
+   * Fires when a user has leaveed a channel
+   * @event CabalDetails#channel-leave
+   * @type {object}
+   * @property {string} channel - Name of the leaved channel
+   * @property {string} key - Public key of the user leaving the channel
+   * @property {boolean} isLocal - True if it was the local user leaving a new channel
+   */
+
+  /**
+   *
+   * Fires when another cabal has been focused
+   * @event CabalDetails#cabal-focus
+   * @type {object}
+   * @property {string} key - Key of the focused cabal
+   */
+
+  /**
+   *
+   * Fires when the local user has connected directly with another peer
+   * @event CabalDetails#started-peering
+   * @type {object}
+   * @property {string} key - Public key of the other peer
+   * @property {string} name- Name of the other peer
+   */
+
+  /**
+   *
+   * Fires when the local user has disconnected with another peer
+   * @event CabalDetails#stopped-peering
+   * @type {object}
+   * @property {string} key - Public key of the other peer
+   * @property {string} name- Name of the other peer
+   */
+
+  
+  /**
+   *
+   * Fires when any kind of change has happened to the cabal.
+   * @event CabalDetails#update
+   */
+
   _emitUpdate(type, payload=null) {
     this.emit('update', this)
     if (type) {

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -57,7 +57,7 @@ class CabalDetails extends EventEmitter {
     if (mention) this.channels[channel].addMention(message)
     this._emitUpdate("new-message", { 
         channel,
-        author: this.users[message.key] || message.key, 
+        author: this.users[message.key] || { key: message.key, name: message.key, local: false, online: false}, 
         message: Object.assign({}, message) 
     })
   }
@@ -295,7 +295,7 @@ class CabalDetails extends EventEmitter {
     return Object.assign({}, this.users)
   }
 
-  /** emits event updates with different types and corresponding payloads. 
+  /** Emits event updates with different types and corresponding payloads. Listen for these events to update state.
   * @example
   * events and payloads are documented as `<type>`: `<payload>|empty`:
   * `init`: empty

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -98,7 +98,7 @@ class CabalDetails extends EventEmitter {
     }
     if (!msg.type) msg.type = "chat/text"
       this._cabal.publish(msg, opts, (err, m) => {
-          this._emitUpdate("publish-message", { msg })
+          this._emitUpdate("publish-message", { message: msg })
           cb(err, m)
       })
   }
@@ -111,7 +111,7 @@ class CabalDetails extends EventEmitter {
   publishNick(nick, cb) {
     this._cabal.publishNick(nick, cb)
     this.user.name = nick
-    this._emitUpdate("publish-nick", { nick })
+    this._emitUpdate("publish-nick", { name: nick })
   }
 
   /**
@@ -299,18 +299,17 @@ class CabalDetails extends EventEmitter {
   * @example
   * events and payloads are documented as `<type>`: `<payload>|empty`:
   * `init`: empty
-  * `nick-change`: `{ key, newNick, oldNick }`
   * `user-updated`: `{ key, user }`
   * `new-channel`: `{ channel }`
   * `new-message`: `{ channel, author: { name, key, local, online }, message }` note: includes chat/topic, chat/emote, chat/text
-  * `publish-message`: `{ msg, timestamp }`
-  * `publish-nick`: `{ nick }`
+  * `publish-message`: `{ message, timestamp }`
+  * `publish-nick`: `{ name }`
   * `status-message`: `{ channel, message }`
   * `topic`: `{ channel, topic }`
   * `channel-focus`: `{ channel }`
-  * `channel-join`: `{ userKey, channel, isLocal }`
-  * `channel-leave`: `{ userKey, channel, isLocal }`
-  * `cabal-focus`: `{ cabalKey }`
+  * `channel-join`: `{ key, channel, isLocal }`
+  * `channel-leave`: `{ key, channel, isLocal }`
+  * `cabal-focus`: `{ cabalkey }`
   * `started-peering`: { key, name }`
   * `stoppped-peering`: { key, name }`
   * `update`: empty - generic update from previous iteration, signals that something changed
@@ -416,7 +415,7 @@ this.registerListener(cabal.memberships.events, 'add', (channel, user) => {
     this.channels[channel] = new ChannelDetails(this._cabal, channel)
   }
   this.channels[channel].addMember(user)
-  this._emitUpdate("channel-join", { channel, userKey: user, isLocal: user === this.user.key })
+  this._emitUpdate("channel-join", { channel, key: user, isLocal: user === this.user.key })
 })
 
 // notify when a user has left a channel
@@ -425,7 +424,7 @@ this.registerListener(cabal.memberships.events, 'remove', (channel, user) => {
     this.channels[channel] = new ChannelDetails(this._cabal, channel)
   }
   this.channels[channel].removeMember(user)
-  this._emitUpdate("channel-leave", { channel, userKey: user, isLocal: user === this.user.key })
+  this._emitUpdate("channel-leave", { channel, key: user, isLocal: user === this.user.key })
 })
 
 // register to be notified of new channels as they are created
@@ -471,7 +470,7 @@ cabal.users.getAll((err, users) => {
     })
     if (!found) {
       this.users[key] = {
-        key: key,
+        key,
         online: true
       }
     }

--- a/src/client.js
+++ b/src/client.js
@@ -179,7 +179,7 @@ class Client {
     }
     this.currentCabal = cabal
     let details = this.cabalToDetails(cabal)
-    details._emitUpdate("cabal-focus", { cabalkey: key })
+    details._emitUpdate("cabal-focus", { key })
     return details
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -162,7 +162,6 @@ class Client {
           const details = new CabalDetails(cabal, cb)
           this.cabals.set(cabal, details)
           cabal.swarm()
-          this.getCurrentCabal()._emitUpdate()
           resolve(details)
         })
       })
@@ -179,7 +178,9 @@ class Client {
       return false
     }
     this.currentCabal = cabal
-    return this.cabalToDetails(cabal)
+    let details = this.cabalToDetails(cabal)
+    details._emitUpdate("cabal-focus", { cabalkey: key })
+    return details
   }
 
   /**
@@ -398,7 +399,6 @@ class Client {
    */
   focusChannel (channel, keepUnread = false, cabal = this.currentCabal) {
     this.cabalToDetails(cabal).focusChannel(channel, keepUnread)
-    this.cabalToDetails(cabal)._emitUpdate()
   }
 
   /**


### PR DESCRIPTION
this pr introduces the modular event listeners we have been craving :3

it needs better documentation and the cli has not been rewritten using only the new listeners. the old update event is still emitted, so integrating the new listeners can be done in a pieacemeal fashion. 

i believe the `init` event will be useful for cli & desktop alike : )

`debug` is also introduced as a module, which allows for really nice logs of events using e.g. the following invocation

```
DEBUG="cabal-client" node cli.js <cabal-key> 2> cabal-debug-log.txt
```

see below for the list of events that are emitted, and please review to find any bugs <3

events and payloads are documented as `<type>`: `<payload>|empty`:
  * `init`: empty
  * `nick-change`: `{ key, newNick, oldNick }`
  * `user-updated`: `{ key, user }`
  * `new-channel`: `{ channel }`
  * `new-message`: `{ channel, author: { name, key, local, online }, message }` note: includes chat/topic, chat/emote, chat/text
  * `publish-message`: `{ msg, timestamp }`
  * `publish-nick`: `{ nick }`
  * `status-message`: `{ channel, message }`
  * `topic`: `{ channel, topic }`
  * `channel-focus`: `{ channel }`
  * `channel-join`: `{ userKey, channel, isLocal }`
  * `channel-leave`: `{ userKey, channel, isLocal }`
  * `cabal-focus`: `{ cabalKey }`
  * `started-peering`: `{ key, name }`
  * `stoppped-peering`: `{ key, name }`
  * `update`: empty - generic update from previous iteration, signals that something changed

some renaming of emitted keys might be warranted to increase cohesion / aesthetics :~~

fixes #23