### PR TITLE
Add additional event for data when processing commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dev": true
     },
     "@hyperswarm/dht": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-3.5.2.tgz",
-      "integrity": "sha512-WMea24RGEDIZYv48rJw60OKaqxER282WmdmbT+CRe7IimNQIZruYLly0lgnC9ZJhhup0WpFSmeh0m6ZEmnMVkg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-3.6.3.tgz",
+      "integrity": "sha512-ft+kjZK6YfxMZQ1rLVEKPug8ClesRbmSDBMY08N0h8LpBZ9ewHLPtf1W3rPeInPJQzcp3vLPHtX/YTngzNZbrA==",
       "requires": {
         "@hyperswarm/hypersign": "^2.0.0",
-        "dht-rpc": "^4.7.0",
+        "dht-rpc": "^4.8.0",
         "end-of-stream": "^1.4.1",
-        "guard-timeout": "^1.0.0",
+        "guard-timeout": "^2.0.0",
         "hashlru": "^2.3.0",
         "protocol-buffers-encodings": "^1.1.0",
         "record-cache": "^1.1.0",
@@ -27,9 +27,9 @@
       }
     },
     "@hyperswarm/discovery": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-1.11.3.tgz",
-      "integrity": "sha512-7LyHGIgDOZ/3ucGK0FYUXKAp+FEjJU0kW+YawxGZb56A5NF34g02o70+bo0WubQa9RthyPx+q0Vesch9ZHdgjw==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-1.11.4.tgz",
+      "integrity": "sha512-IZ902SwvoV7CAnsNvCymV8CdFUOupNB6Shk207sUQfK7b3qHc/hP90bu0xsVDrao+YCQPC3J6Zdpb+Q047MBTg==",
       "requires": {
         "@hyperswarm/dht": "^3.2.0",
         "multicast-dns": "^7.2.0",
@@ -45,9 +45,9 @@
       }
     },
     "@hyperswarm/network": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hyperswarm/network/-/network-1.3.2.tgz",
-      "integrity": "sha512-hD1x7b0mwhjPfIcjp3ZV9XhJySPmUvCKQ7VdzlgYoOfZadHk5SQl4gOzb8T/4EHTy/OqW31zCZNZGbvzjw1nkg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/network/-/network-1.5.0.tgz",
+      "integrity": "sha512-EtEGUew6+odJSMwbpzzSxtX7VXTDUQ16b/w7jl9MXegKPjQkLTVkGf18luO/sjWC8N81u5XEeabi6x4oKuP1tQ==",
       "requires": {
         "@hyperswarm/discovery": "^1.6.0",
         "nanoresource": "^1.0.0",
@@ -328,16 +328,16 @@
       }
     },
     "cabal-core": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-10.0.0.tgz",
-      "integrity": "sha512-AqWx4EOENbAoTS6jOtxbVChpZ7a0+0f4IWJK4L2X9eiD1pk3dTqhT9Oa8s3k13Pysg12jRFbqg+7BIKHjZ5kOA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-10.0.1.tgz",
+      "integrity": "sha512-QcBsfYRsoIhZ1zBH4xfve2twA6u3QcuqeaOHvXioL/V7ZNoTASFnOnI1blHMToXKu2Sao/vArUxh6mlteEw+Qg==",
       "requires": {
         "charwise": "^3.0.1",
         "concat-stream": "^2.0.0",
         "dat-encoding": "^5.0.1",
         "debug": "^4.1.1",
         "hypercore-crypto": "^1.0.0",
-        "hyperswarm": "^2.8.0",
+        "hyperswarm": "^2.13.0",
         "inherits": "^2.0.4",
         "kappa-core": "^6.0.0",
         "kappa-view-level": "^2.0.1",
@@ -387,6 +387,11 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "catharsis": {
       "version": "0.8.11",
@@ -460,15 +465,50 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "codecs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.0.0.tgz",
-      "integrity": "sha512-WXvpJRAgc693oqYvZte9uYEiL5YHtfrxyEq12uVny9oBJ1k37zSva5vVz7trsnt6R9Y15hEgOSC7VFZT2pfYnA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.1.0.tgz",
+      "integrity": "sha512-nSWYToViFEpZXOxhtMQ6IDs76TN9xKIkHOu1KCr/iFiBcgzKuY1AFPZktuXN8r82FbZ/TXP9fwITszLgcp3eQg=="
     },
     "collect-all": {
       "version": "1.0.3",
@@ -528,7 +568,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -536,8 +575,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "command-line-args": {
       "version": "5.1.1",
@@ -763,6 +801,11 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -831,9 +874,9 @@
       }
     },
     "dht-rpc": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-4.7.1.tgz",
-      "integrity": "sha512-cz9RDGk4bTfu69M3NmLO5HD8esFdWXf58swoouw26tyBnrfFMRZdTlxwhcDk6vMIAkDvio47GcvmHCi/HdqEoA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-4.8.1.tgz",
+      "integrity": "sha512-5x+1nrAXIOaclICKI3hj1LpP2SW/aDw/Rzz76KWZNCtmqhPkxIHMdqLPL2ozw4DuqX2Uq/Wr9FE5dSFbNt/YyA==",
       "requires": {
         "codecs": "^2.0.0",
         "ipv4-peers": "^2.0.0",
@@ -845,6 +888,11 @@
         "time-ordered-set": "^1.0.1",
         "xor-distance": "^2.0.0"
       }
+    },
+    "dijkstrajs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
+      "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
     },
     "dmd": {
       "version": "4.0.6",
@@ -902,6 +950,11 @@
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.0"
       }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encoding-down": {
       "version": "6.3.0",
@@ -1537,6 +1590,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -1570,9 +1628,9 @@
       "dev": true
     },
     "guard-timeout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/guard-timeout/-/guard-timeout-1.0.2.tgz",
-      "integrity": "sha512-pHBSeiEgAFMhZP3dycr5Fgs3NBnuyeELDYhUez9Nd6UDnMp/qkSr3xsXcjx9upfOozGZaassJtgv7nrqwXBlyA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/guard-timeout/-/guard-timeout-2.0.0.tgz",
+      "integrity": "sha512-35geHv72oal0cRUE5t1tZ5KHm3OVPXzFtiMG8AnRPV5FkkEf84RUpeQ0BCeCZunfSLGATW5ZVyALhJKgM7I/6A=="
     },
     "handlebars": {
       "version": "4.7.6",
@@ -1638,9 +1696,9 @@
       "dev": true
     },
     "hypercore": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-8.12.0.tgz",
-      "integrity": "sha512-sujt1JtufgvZDVhazrfEmTLAfIAVtF7eMk5aIgak057O6zDil8JkYhtcZcJHy8DquqX3n0chMLloHiJI8yeHlg==",
+      "version": "8.13.2",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-8.13.2.tgz",
+      "integrity": "sha512-wARKZRJaSwCgMjQWym8va+DciEbK4UpPZYiQSjEBx721jlw+76hLYb5qZnRHiLDXyQuuuSk/plJALxkW08UqFg==",
       "requires": {
         "abstract-extension": "^3.0.1",
         "atomic-batcher": "^1.0.2",
@@ -1704,13 +1762,13 @@
       }
     },
     "hyperswarm": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.11.1.tgz",
-      "integrity": "sha512-kxE2cyc9H73gmfr+6JkI2NXxRcVEu4j4etXWkS8Xim8tQy/JoG9iE8EHXE+gfhTnXg5ZIp6n5UAGtraI9AgMvA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.13.0.tgz",
+      "integrity": "sha512-w9YKJJXvvjP7K4ywCH2mf53vDhbL57fH8dxd0UJ9HzTSFqY/KNJVNRKplPn/mVscVo4tfOkjpdaHh12y9RwrxQ==",
       "requires": {
-        "@hyperswarm/network": "^1.2.0",
+        "@hyperswarm/network": "^1.5.0",
         "shuffled-priority-queue": "^2.1.0",
-        "utp-native": "^2.1.3"
+        "utp-native": "^2.1.7"
       }
     },
     "iconv-lite": {
@@ -1821,8 +1879,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-options": {
       "version": "1.0.1",
@@ -2464,9 +2521,9 @@
       "dev": true
     },
     "materialized-group-auth": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/materialized-group-auth/-/materialized-group-auth-1.1.3.tgz",
-      "integrity": "sha512-VlmHVEdzogn2FtyufZ9glzg1mj/SOHRFTqGMt5Bw9O2gwysQdKRvRECRSjiLF0WEfSgR98/01HymMHBjZZaZSA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/materialized-group-auth/-/materialized-group-auth-1.2.0.tgz",
+      "integrity": "sha512-fDSF+vLqJcezJknadEQAKSUVJBzgswYFfbPIrSrhnKsmeX1PAbUx6YVwf0sYpl/aizm6uiaoZK1rfRg0qmC57A==",
       "requires": {
         "collect-stream": "^1.2.1",
         "duplexify": "^4.0.0",
@@ -2627,9 +2684,9 @@
       }
     },
     "multifeed-index": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.4.0.tgz",
-      "integrity": "sha512-ARD4M34x5wc+rgDS5pTvs9ut7+RL3VqWrdMK839ID6iKPPMKlUqFU4swjHLwScQ/UJS0X4HQO0940J01m83Dmw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.4.1.tgz",
+      "integrity": "sha512-Z0hWW207BN/TSQ1iW4VSJoO2vHoEYqbUDYdh/VZul1Pj15HmufksHLqAOND5BqhDTGBa+CgWxbgXh2Ofe57emw==",
       "requires": {
         "clone": "^2.1.2",
         "inherits": "^2.0.3"
@@ -2642,9 +2699,9 @@
       "dev": true
     },
     "mutexify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.2.0.tgz",
-      "integrity": "sha512-oprzxd2zhfrJqEuB98qc1dRMMonClBQ57UPDjnbcrah4orEMTq1jq3+AcdFe5ePzdbJXI7zmdhfftIdMnhYFoQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.0.tgz",
+      "integrity": "sha512-WNPlgZ3AHETGSa4jeRP4aW6BPQ/a++MwoMFFIgrDg80+m70mbxuNOrevANfBDmur82zxTFAY3OwvMAvqrkV2sA=="
     },
     "nan": {
       "version": "2.14.0",
@@ -2693,9 +2750,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-      "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
     },
     "noise-protocol": {
       "version": "1.0.0",
@@ -2828,8 +2885,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2936,6 +2992,11 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -2998,10 +3059,31 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qrcode": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
+      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "buffer-alloc": "^1.2.0",
+        "buffer-from": "^1.1.1",
+        "dijkstrajs": "^1.0.1",
+        "isarray": "^2.0.1",
+        "pngjs": "^3.3.0",
+        "yargs": "^13.2.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "query-string": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.0.tgz",
-      "integrity": "sha512-aoiFW9ZU7jP8Itjqfpw80Qe7RoyCIhFrW522sdsp9LG92pat6CCG3d8qNZBaUi71FsEjIfLjx9Ky347FtVoqXA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
+      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -3200,6 +3282,16 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -3301,6 +3393,11 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3679,9 +3776,9 @@
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+          "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
           "requires": {
             "buffer": "^5.5.0",
             "immediate": "^3.2.3",
@@ -3697,6 +3794,20 @@
           "requires": {
             "abstract-leveldown": "~6.2.1",
             "inherits": "^2.0.3"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "6.2.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+              "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+              "requires": {
+                "buffer": "^5.5.0",
+                "immediate": "^3.2.3",
+                "level-concat-iterator": "~2.0.0",
+                "level-supports": "~1.0.0",
+                "xtend": "~4.0.0"
+              }
+            }
           }
         },
         "level-errors": {
@@ -3725,9 +3836,9 @@
           }
         },
         "levelup": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz",
-          "integrity": "sha512-cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+          "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
           "requires": {
             "deferred-leveldown": "~5.3.0",
             "level-errors": "~2.0.0",
@@ -3985,9 +4096,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.1.7.tgz",
-      "integrity": "sha512-PQmXCdZOkmADtIqmhoiFEIdNlvkPouO8ktXqThFDBAt850B752bjQMF5KAJeMBJ5gzuI70ZiP9Qsr9mwCwzSyg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.1.10.tgz",
+      "integrity": "sha512-VTjBvb/uE9gYqx2NGVPtAWhqv9itieW+wJceJg5G6Cl/2kBCnHDaFafw3fNgCvii7meTpC4AoZfy6OG0pnuQ/Q==",
       "requires": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -4026,6 +4137,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -4040,6 +4156,49 @@
       "requires": {
         "reduce-flatten": "^1.0.1",
         "typical": "^2.6.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -4076,6 +4235,100 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "cabal-core": "^10.0.0",
+    "cabal-core": "^10.0.1",
     "collect-stream": "^1.2.1",
     "dat-dns": "^4.0.1",
     "debug": "^4.1.1",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -45,6 +45,9 @@ class CabalDetails extends EventEmitter {
       info: (msg) => {
         this._emitUpdate("info", msg)
       },
+      data: ({ command, data, arg }) => {
+        this._emitUpdate("command", { command: command, data: data, arg: arg })
+      },
       error: (err) => {
         this._emitUpdate("error", err)
       },


### PR DESCRIPTION
Cabal Desktop needs to do some cleanup after a /command happens. This adds an extra "command" event that contains what command was typed, the args that were typed, and any relevant data that was generated from it.