### PR TITLE
adds /ban, /unban, /baninfo, /banlist, /role, /mod, and /admin commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "level": "^6.0.0",
     "memdb": "^1.3.1",
     "mkdirp": "^0.5.1",
+    "pump": "^3.0.0",
     "qrcode": "^1.4.4",
-    "random-access-memory": "^3.1.1"
+    "random-access-memory": "^3.1.1",
+    "to2": "^1.0.0"
   },
   "devDependencies": {
     "jsdoc-to-markdown": "^5.0.2",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -38,6 +38,7 @@ class CabalDetails extends EventEmitter {
   constructor({ cabal, client, commands, aliases }, done) {
     super()
     this._cabal = cabal
+    this.core = cabal
     this.client = client
     this._commands = commands || {}
     this._aliases = aliases || {}


### PR DESCRIPTION
depends on https://github.com/cabal-club/cabal-core/pull/80

I've tested some scenarios on a local cabal (but not all). I was able to add an admin, see their ban (with /banlist) and see the ban disappear with /unban.