### PR TITLE
Expand dat-dns regexes, enabling sharing default mod key via dns

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -53,8 +53,8 @@ class Client {
     let cabalDnsOpts = {
       hashRegex: /^[0-9a-f]{64}?$/i,
       recordName: 'cabal',
-      protocolRegex: /^cabal:\/\/([0-9a-f]{64}(\?((admin|mod)=[0-9a-f]{64})(&(admin|mod)=[0-9a-f]{64})*)?)/i,
-      txtRegex: /^"?cabalkey=([0-9a-f]{64}(\?((admin|mod)=[0-9a-f]{64})(&(admin|mod)=[0-9a-f]{64})*)?)"?$/i
+      protocolRegex: /^(cabal:\/\/[0-9A-Fa-f]{64}\b.*)/i,
+      txtRegex: /^"?cabalkey=(cabal:\/\/[0-9A-Fa-f]{64}\b.*)"?$/i
     }
     // also takes opts.persistentCache which has a read and write function
     //   read: async function ()   // aka cache lookup function

--- a/src/client.js
+++ b/src/client.js
@@ -53,8 +53,8 @@ class Client {
     let cabalDnsOpts = {
       hashRegex: /^[0-9a-f]{64}?$/i,
       recordName: 'cabal',
-      protocolRegex: /^cabal:\/\/([0-9a-f]{64})/i,
-      txtRegex: /^"?cabalkey=([0-9a-f]{64})"?$/i
+      protocolRegex: /^cabal:\/\/([0-9a-f]{64}(\?((admin|mod)=[0-9a-f]{64})(&(admin|mod)=[0-9a-f]{64})*)?)/i,
+      txtRegex: /^"?cabalkey=([0-9a-f]{64}(\?((admin|mod)=[0-9a-f]{64})(&(admin|mod)=[0-9a-f]{64})*)?)"?$/i
     }
     // also takes opts.persistentCache which has a read and write function
     //   read: async function ()   // aka cache lookup function


### PR DESCRIPTION
For [the moderation grant](https://opencollective.com/cabal-club/updates/cabal-x-subjective-moderation-mozilla-grant) we have been talking about enabling people to set a default administrator, or moderator. 

The reasoning is, without that ability, entering a cabal for the first time as a new person risks exposing people to a bunch of trolls or other malicious participants which have already been blocked by the regular people in the cabal.

The way to do it with out dns, which at least I advocate for, is setting moderators & administrators via URL parameters, as in:
```
cabal://<cabal key>?mod=<public key of moderator>&admin=<public key of administrator>
```

The tricky part seemed to be how we add support for that to the [DNS shortnames](https://github.com/datprotocol/dat-dns/pull/15), which enable people to join cabal via existing domain names as in `cabal://cabal.chat`. (See the DNS shortname link for more info.)

I was just experimenting with a shortname solution, and realized we could just use the former way of setting admin & mod keys as URL parameters, and reusing the solution for the DNS shortname method. That's what this PR introduces.

See this regexr example of what the extended regexes matches against https://regexr.com/54f5g

⚠️ _this PR needs a companion PR in cabal-core for the passed in mod key [not to be rejected as an error](https://github.com/cabal-club/cabal-core/blob/9a0f6e7395ed707d1f348b0049ce20f199cfcfe9/index.js#L59-L62)_