### PR TITLE
fix init event not being emitted correctly

### DIFF
--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -562,9 +562,9 @@ class CabalDetails extends EventEmitter {
     })
   }
 
-  _initializeLocalUser(done) {
+  _initializeLocalUser(cb) {
     this.core.getLocalKey((err, lkey) => {
-      if (err) return done(err)
+      if (err) return cb(err)
       this.user = new User()
       this.user.key = lkey
       this.user.local = true
@@ -573,8 +573,7 @@ class CabalDetails extends EventEmitter {
       // try to get more data for user
       this.core.users.get(lkey, (err, user) => {
         if (err || !user) { 
-            this._emitUpdate("init")
-            done(null)
+            cb(null)
             return
         }
         this.user = new User(user)
@@ -583,8 +582,7 @@ class CabalDetails extends EventEmitter {
         this.user.local = true
         this.user.online = true
         this.users[lkey] = this.user
-        this._emitUpdate("init") // TODO: revise this event (is it the final init?)
-        done(null)
+        cb(null)
       })
     })
   }

--- a/src/client.js
+++ b/src/client.js
@@ -193,6 +193,7 @@ class Client {
           this.cabals.set(cabal, details)
           if (!opts.noSwarm) cabal.swarm()
           function done () {
+            details._emitUpdate('init')
             cb()
             resolve(details)
           }


### PR DESCRIPTION
after #39 landed, it seems like the `init` event was not being emitted correctly for desktop. i had a look around and i might have found the culprit

cc @nikolaiwarner 