### PR TITLE
add moderation class, new cmd /moderation, and fix cmd output

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "level": "^6.0.0",
     "memdb": "^1.3.1",
     "mkdirp": "^0.5.1",
+    "monotonic-timestamp": "0.0.9",
     "pump": "^3.0.0",
     "qrcode": "^1.4.4",
     "random-access-memory": "^3.1.1",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -113,10 +113,12 @@ class CabalDetails extends EventEmitter {
     var m = /^\/(\w+)(?:\s+(.*))?/.exec(line.trimRight())
     if (m && this._commands[m[1]] && typeof this._commands[m[1]].call === 'function') {
       this._commands[m[1]].call(this, this._res, m[2])
+      this._emitUpdate("command", { command: m[1], arg: m[2] || '' })
     } else if (m && this._aliases[m[1]]) {
       var key = this._aliases[m[1]]
       if (this._commands[key]) {
         this._commands[key].call(this, this._res, m[2])
+        this._emitUpdate("command", { command: key, arg: m[2] || ''})
       } else {
         this._res.info(`command for alias ${m[1]} => ${key} not found`)
         cb()

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -252,6 +252,7 @@ class CabalDetails extends EventEmitter {
    */
   addStatusMessage(message, channel=this.chname) {
     if (!this.channels[channel]) return
+    debug(channel)
     this.channels[channel].addVirtualMessage(message)
     this._emitUpdate("status-message", { channel, message })
   }

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events')
 const debug = require("debug")("cabal-client")
 const { VirtualChannelDetails, ChannelDetails } = require("./channel-details")
 const User = require("./user")
+const Moderation = require("./moderation")
 const collect = require('collect-stream')
 const { nextTick } = process
 
@@ -61,6 +62,7 @@ class CabalDetails extends EventEmitter {
       }
     }
     this.key = cabal.key
+    this.moderation = new Moderation(this.core)
     
     this.channels = {
       '!status': new VirtualChannelDetails("!status"),

--- a/src/channel-details.js
+++ b/src/channel-details.js
@@ -1,4 +1,5 @@
 const collect = require('collect-stream')
+const timestamp = require("monotonic-timestamp")
 const { stableSort, merge } = require('./util')
 
 class ChannelDetailsBase {
@@ -90,7 +91,7 @@ class ChannelDetailsBase {
     const virtualMessages = this.getVirtualMessages(opts)
     var cmp = (a, b) => {
       // sort by timestamp
-      let diff = parseInt(a.value.timestamp) - parseInt(b.value.timestamp) 
+      let diff = parseFloat(a.value.timestamp) - parseFloat(b.value.timestamp) 
       // if timestamp was the same, and messages are by same author, sort by seqno
       if (diff === 0 
         && a.key && b.key && a.key === b.key 
@@ -125,7 +126,7 @@ class ChannelDetailsBase {
        msg = {
          key: this.name,
          value: {
-           timestamp: msg.timestamp || Date.now(),
+           timestamp: msg.timestamp || timestamp(),
            type: msg.type || "status",
            content: {
              text: msg.text

--- a/src/client.js
+++ b/src/client.js
@@ -148,6 +148,7 @@ class Client {
     let cabalPromise
     let dnsFailed = false
     if (typeof key === 'string') {
+      key = key.trim()
       cabalPromise = this.resolveName(key).then((resolvedKey) => {
         if (resolvedKey === null) {
           dnsFailed = true

--- a/src/commands.js
+++ b/src/commands.js
@@ -43,6 +43,14 @@ module.exports = {
       })
     }
   },
+  share: { 
+    help: () => 'print a cabal key with you as admin. useful for sending to friends',
+    call: (cabal, res, arg) => {
+      const adminkey = `cabal://${cabal.key}?admin=${cabal.user.key}`
+      res.info(adminkey, { data: { adminkey }})
+      res.end()
+    }
+  },
   ids: {
     help: () => 'toggle showing ids at the end of nicks. useful for moderation',
     call: (cabal, res, arg) => {

--- a/src/moderation.js
+++ b/src/moderation.js
@@ -1,0 +1,108 @@
+const pump = require('pump')
+const to = require('to2')
+
+class Moderation {
+  constructor (core) { 
+    this.core = core
+  }
+
+  getAdmins (channel) {
+    return this._listCmd('admin', channel)
+  }
+
+  getMods (channel) {
+    return this._listCmd('mod', channel)
+  }
+
+  getHides (channel) {
+    return this._listCmd('hide', channel)
+  }
+
+  getBlocks (channel) {
+    return this._listCmd('block', channel)
+  }
+
+  hide (id, opts) {
+    opts = opts || {}
+    return this.setFlag('hide', 'add', opts.channel, id, opts.reason)
+  }
+
+  unhide (id, opts) {
+    opts = opts || {}
+    return this.setFlag('hide', 'remove', opts.channel, id, opts.reason)
+  }
+
+  block (id, opts) {
+    opts = opts || {}
+    return this.setFlag('block', 'add', opts.channel, id, opts.reason)
+  }
+
+  unblock (id, opts) {
+    opts = opts || {}
+    return this.setFlag('block', 'remove', opts.channel, id, opts.reason)
+  }
+
+  addAdmin (id, opts) {
+    opts = opts || {}
+    return this.setFlag('admin', 'add', id, opts.channel, opts.reason)
+  }
+
+  removeAdmin (id, opts) {
+    opts = opts || {}
+    return this.setFlag('admin', 'remove', opts.channel, id, opts.reason)
+  }
+
+  addMod (id, opts) {
+    opts = opts || {}
+    return this.setFlag('mod', 'add', opts.channel, id, opts.reason)
+  }
+
+  removeMod (id, opts) {
+    opts = opts || {}
+    return this.setFlag('mod', 'remove', opts.channel, id, opts.reason)
+  }
+
+  setFlag (flag, type, channel='@', id, reason='') {
+    // a list of [[id, reason]] was passed in
+    if (typeof id[Symbol.iterator] === 'function') {
+      const promises = id.map((entry) => { return this._flagCmd(flag, type, channel, entry[0], entry[1]) })
+      return Promise.all(promises)
+    }
+    return this._flagCmd(flag, type, id, channel, reason)
+  }
+
+  _flagCmd (flag, type, channel='@', id, reason='') {
+    const fname = (type === 'add' ? 'addFlags' : 'removeFlags')
+    return new Promise((resolve, reject) => {
+      this.core.moderation[fname]({
+        id,
+        channel,
+        flags: [flag],
+        reason
+      }, (err) => {
+        if (err) { return reject(err) }
+        else { resolve() }
+      })
+    })
+  }
+
+  _listCmd (cmd, channel='@') {
+    const keys = []
+    return new Promise((resolve, reject) => {
+      const write = (row, enc, next) => {
+        keys.push(row.id)
+        next()
+      }
+      const end = (next) => {
+        next()
+        resolve(keys)
+      }
+      pump(
+        this.core.moderation.listByFlag({ flag: cmd, channel }),
+        to.obj(write, end)
+      )
+    })
+  }
+}
+
+module.exports = Moderation


### PR DESCRIPTION
this pr moves some of the moderation commands from `commands.js` to a new class, and exposes a bunch of methods. 

the intent is for clients other than the terminal client to be able to easily use moderation commands. e.g. cabal desktop can tie menu actions to moderation commands more easily

* a bunch of moderation commands are now exposed on each cabal-details instance e.g. `details.moderation`, see moderation.js for the full listing atm
* `/moderation` is a new command for showing moderation related commands
* output from `/help` has been fixed by making use of monotonic timestamps
* adds new event, `command`: `details.on('command', ({ command, arg })`