### PR TITLE
improve user feedback when interacting with moderation

### DIFF
--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -673,26 +673,6 @@ class CabalDetails extends EventEmitter {
 
     // Load moderation state
     const loadModerationState = (cb) => {
-	  const promises = [this.moderation.getAdmins(), this.moderation.getMods()]
-	  // get all moderation actions issued by our current mods & admins
-	  Promise.all(promises).then(results => {
-		const keys = results[0].concat(results[1])
-		keys.forEach(key => {
-		  const write = (row, enc, next) => {
-			if (!row) return
-			const name = this.users[key].name || key.slice(0, 8)
-			const target = this.users[row.content.id].name || row.content.id.slice(0, 8)
-			const action = row.type.split("/")[1]
-			const reason = row.content.reason
-			const role = row.content.flags[0]
-			const text = `${name} ${action === "remove" ? "removed" : "added"} ${target} as ${role} ${reason ? "reason: " + reason : ''}`
-			this.addStatusMessage({ text, timestamp: row.timestamp })
-			next()
-		  }
-		  const end = (next) => { next() }
-		  pump(this.core.moderation.listModerationBy(key), to.obj(write, end))
-		})
-      })
       cabal.moderation.list((err, list) => {
         if (err) return cb(err)
         list.forEach(info => {
@@ -734,7 +714,7 @@ class CabalDetails extends EventEmitter {
 			this.core.getMessage(info.key, (err, doc) => {
 			  const issuerName = issuer.name || info.by.slice(0, 8)
 			  const role = doc.content.flags[0]
-			  const reason = doc.content.reason.? `(reason: ${doc.content.reason})` : ''
+			  const reason = doc.content.reason ? `(reason: ${doc.content.reason})` : ''
 			  // there was no change in behaviour, e.g. someone modded an already
 			  // modded person, hid someone that was already hidden
 			  const changeOccurred = Object.keys(changedRole).filter(r => changedRole[r]).length > 0

--- a/src/channel-details.js
+++ b/src/channel-details.js
@@ -79,12 +79,12 @@ class ChannelDetailsBase {
 
   getVirtualMessages(opts) {
     const limit = opts.limit
-    const newerThan = opts.gt || 0
-    const olderThan = opts.lt || Infinity
+    const newerThan = parseFloat(opts.gt || 0)
+    const olderThan = parseFloat(opts.lt || Infinity)
     var filtered = this.virtualMessages.filter((m) => {
-      return (m.value.timestamp > newerThan && m.value.timestamp < olderThan)
+      return (parseFloat(m.value.timestamp) > newerThan && parseFloat(m.value.timestamp) < olderThan)
     })
-    return stableSort(filtered, v => v.value.timestamp).slice(-limit)
+    return stableSort(filtered, v => parseFloat(v.value.timestamp)).slice(-limit)
   }
 
   interleaveVirtualMessages(messages, opts) {
@@ -197,7 +197,7 @@ class VirtualChannelDetails extends ChannelDetailsBase {
   }
 
   getPage(opts) {
-    return Promise.resolve(this.getVirtualMessages(opts))
+    return Promise.resolve(this.interleaveVirtualMessages([], opts))
   }
 }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -523,7 +523,27 @@ function flagCmd (cmd, cabal, res, arg) {
   var flag = cmd.replace(/^un/,'')
   var reason = args.slice(1).join(' ')
   cabal.moderation._flagCmd(flag, type, channel, id, reason).then(() => {
-      res.info(`${/^un/.test(cmd) ? 'removed' : 'added'} flag ${flag} for ${id}`)
+	  if (["admin", "mod"].includes(flag)) {
+		if (/^un/.test(cmd) && flag === "mod" && !cabal.users[id].isModerator()) {
+		  res.error(`${getPeerName(cabal, id)} is not a mod`)
+		} else if (/^un/.test(cmd) && flag === "admin" && !cabal.users[id].isAdmin()) {
+		  res.error(`${getPeerName(cabal, id)} is not an admin`)
+		} else if (!/^un/.test(cmd) && flag === "mod" && cabal.users[id].isModerator()) {
+		  res.error(`${getPeerName(cabal, id)} is already a mod`)
+		} else if (!/^un/.test(cmd) && flag === "admin" && cabal.users[id].isAdmin()) {
+		  res.error(`${getPeerName(cabal, id)} is already an admin`)
+		} else {
+		  res.info(`${/^un/.test(cmd) ? 'removed' : 'added'} ${flag} for ${getPeerName(cabal, id)}`)
+		}
+	  } else {
+		if (/^un/.test(cmd)) {
+		  if (!cabal.users[id].isHidden()) { res.error(`cannot unhide ${getPeerName(cabal, id)}: they are not hidden`) }
+		  else { res.info(`removed hide for ${getPeerName(cabal, id)}`) }
+		} else {
+		  if (cabal.users[id].isHidden()) { res.error(`${getPeerName(cabal, id)} is already hidden`) }
+		  else { res.info(`${getPeerName(cabal, id)}'s messages are now hidden`) }
+		}
+	  }
       res.end()
   }).catch((err) => { res.error(err) })
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -326,12 +326,16 @@ module.exports = {
     }
   },
   actions: {
-    help: () => 'print out a historic log of the moderation actions applied by you, your active moderators and admins',
+    help: () => 'print out a historic log of the moderation actions applied by you, and your active moderators & admins',
     call: (cabal, res, arg) => {
 	  const promises = [cabal.moderation.getAdmins(), cabal.moderation.getMods()]
 	  // get all moderation actions issued by our current mods & admins
       const messages = []
       function processMessages (messages) {
+        res.info("moderation actions")
+        if (messages.length === 0) {
+          res.info("no recorded historic moderation actions")
+        }
         messages.sort((a, b) => { return a.timestamp - b.timestamp })
         messages.forEach((message) => {
           res.info(message.text)
@@ -386,6 +390,11 @@ module.exports = {
 		  }
 		}
 		res.info("moderation roles")
+        if (keys.length === 1 && keys[0] === cabal.getLocalUser().key) {
+          res.info("you currently have no applied moderators or admins, other than yourself")
+          res.info("see /moderation, for how to add some")
+          return res.end()
+        }
 		const printMods = print("moderator")
 		const printAdmins = print("admin")
 		results[0].map(printAdmins)

--- a/src/commands.js
+++ b/src/commands.js
@@ -577,7 +577,7 @@ function flagCmd (cmd, cabal, res, arg) {
   var type = /^un/.test(cmd) ? 'remove' : 'add'
   var flag = cmd.replace(/^un/,'')
   var reason = args.slice(1).join(' ')
-  cabal.moderation._flagCmd(flag, type, channel, id, reason).then(() => {
+  cabal.moderation.setFlag(flag, type, channel, id, reason).then(() => {
 	  if (["admin", "mod"].includes(flag)) {
 		if (/^un/.test(cmd) && flag === "mod" && !cabal.users[id].isModerator()) {
 		  res.error(`${getPeerName(cabal, id)} is not a mod`)

--- a/src/commands.js
+++ b/src/commands.js
@@ -332,6 +332,7 @@ module.exports = {
 	  // get all moderation actions issued by our current mods & admins
 	  Promise.all(promises).then(results => {
 		const keys = results[0].concat(results[1])
+        // TODO: collect and sort messages according to timestamp, before emitting them
 		keys.forEach(key => {
 		  const write = (row, enc, next) => {
 			if (!row) return

--- a/src/commands.js
+++ b/src/commands.js
@@ -348,8 +348,8 @@ module.exports = {
           var key = keys.shift()
 		  const write = (row, enc, next) => {
 			if (!row) return
-			const name = cabal.users[key].name || key.slice(0, 8)
-			const target = cabal.users[row.content.id].name || row.content.id.slice(0, 8)
+			const name = cabal.users[key] ? cabal.users[key].name : key.slice(0, 8)
+			const target = cabal.users[row.content.id] ? cabal.users[row.content.id].name : row.content.id.slice(0, 8)
 			const type = row.type.split("/")[1]
 			const reason = row.content.reason
 			const role = row.content.flags[0]
@@ -577,26 +577,27 @@ function flagCmd (cmd, cabal, res, arg) {
   var type = /^un/.test(cmd) ? 'remove' : 'add'
   var flag = cmd.replace(/^un/,'')
   var reason = args.slice(1).join(' ')
+  const reasonstr = reason ? '(reason: ' + reason + ')' : ''
   cabal.moderation.setFlag(flag, type, channel, id, reason).then(() => {
-	  if (["admin", "mod"].includes(flag)) {
-		if (/^un/.test(cmd) && flag === "mod" && !cabal.users[id].isModerator()) {
+	  if (['admin', 'mod'].includes(flag)) {
+		if (/^un/.test(cmd) && flag === 'mod' && !cabal.users[id].isModerator()) {
 		  res.error(`${getPeerName(cabal, id)} is not a mod`)
-		} else if (/^un/.test(cmd) && flag === "admin" && !cabal.users[id].isAdmin()) {
+		} else if (/^un/.test(cmd) && flag === 'admin' && !cabal.users[id].isAdmin()) {
 		  res.error(`${getPeerName(cabal, id)} is not an admin`)
-		} else if (!/^un/.test(cmd) && flag === "mod" && cabal.users[id].isModerator()) {
+		} else if (!/^un/.test(cmd) && flag === 'mod' && cabal.users[id].isModerator()) {
 		  res.error(`${getPeerName(cabal, id)} is already a mod`)
-		} else if (!/^un/.test(cmd) && flag === "admin" && cabal.users[id].isAdmin()) {
+		} else if (!/^un/.test(cmd) && flag === 'admin' && cabal.users[id].isAdmin()) {
 		  res.error(`${getPeerName(cabal, id)} is already an admin`)
 		} else {
-		  res.info(`${/^un/.test(cmd) ? 'removed' : 'added'} ${flag} for ${getPeerName(cabal, id)}`)
+		  res.info(`${/^un/.test(cmd) ? 'removed' : 'added'} ${flag} for ${getPeerName(cabal, id)} ${reasonstr}`)
 		}
 	  } else {
 		if (/^un/.test(cmd)) {
 		  if (!cabal.users[id].isHidden()) { res.error(`cannot unhide ${getPeerName(cabal, id)}: they are not hidden`) }
-		  else { res.info(`removed hide for ${getPeerName(cabal, id)}`) }
+		  else { res.info(`removed hide for ${getPeerName(cabal, id)} ${reasonstr}`) }
 		} else {
 		  if (cabal.users[id].isHidden()) { res.error(`${getPeerName(cabal, id)} is already hidden`) }
-		  else { res.info(`${getPeerName(cabal, id)}'s messages are now hidden`) }
+		  else { res.info(`${getPeerName(cabal, id)}'s messages are now hidden ${reasonstr}`) }
 		}
 	  }
       res.end()

--- a/src/moderation.js
+++ b/src/moderation.js
@@ -65,25 +65,32 @@ class Moderation {
   setFlag (flag, type, channel='@', id, reason='') {
     // a list of [[id, reason]] was passed in
     if (typeof id[Symbol.iterator] === 'function') {
-      const promises = id.map((entry) => { return this._flagCmd(flag, type, channel, entry[0], entry[1]) })
-      return Promise.all(promises)
+      const promises = id.map((entry) => { return new Promise((resolve, reject) => {
+        this._flagCmd(flag, type, channel, entry[0], entry[1], (err) => {
+          if (err) { return reject(err) }
+          else { resolve() }
+        })
+      })
+        return Promise.all(promises)
+      })
     }
-    return this._flagCmd(flag, type, id, channel, reason)
-  }
-
-  _flagCmd (flag, type, channel='@', id, reason='') {
-    const fname = (type === 'add' ? 'addFlags' : 'removeFlags')
     return new Promise((resolve, reject) => {
-      this.core.moderation[fname]({
-        id,
-        channel,
-        flags: [flag],
-        reason
-      }, (err) => {
+      this._flagCmd(flag, type, id, channel, reason, (err) => {
         if (err) { return reject(err) }
         else { resolve() }
       })
     })
+  }
+
+  // type should be either 'add' or 'remove'
+  _flagCmd (flag, type, channel='@', id, reason='', cb) {
+    const fname = (type === 'add' ? 'addFlags' : 'removeFlags')
+    return this.core.moderation[fname]({
+        id,
+        channel,
+        flags: [flag],
+        reason
+      }, cb)
   }
 
   _listCmd (cmd, channel='@') {

--- a/src/moderation.js
+++ b/src/moderation.js
@@ -44,7 +44,7 @@ class Moderation {
 
   addAdmin (id, opts) {
     opts = opts || {}
-    return this.setFlag('admin', 'add', id, opts.channel, opts.reason)
+    return this.setFlag('admin', 'add', opts.channel, id, opts.reason)
   }
 
   removeAdmin (id, opts) {
@@ -64,25 +64,27 @@ class Moderation {
 
   setFlag (flag, type, channel='@', id, reason='') {
     // a list of [[id, reason]] was passed in
-    if (typeof id[Symbol.iterator] === 'function') {
-      const promises = id.map((entry) => { return new Promise((resolve, reject) => {
-        this._flagCmd(flag, type, channel, entry[0], entry[1], (err) => {
-          if (err) { return reject(err) }
-          else { resolve() }
-        })
-      })
-        return Promise.all(promises)
-      })
-    }
+	if (typeof id === "object" && typeof id[Symbol.iterator] === 'function') {
+	  const promises = id.map((entry) => { 
+		return new Promise((resolve, reject) => {
+		  this._flagCmd(flag, type, channel, entry[0], entry[1], (err) => {
+			if (err) { return reject(err) }
+			else { resolve() }
+		  })
+		})
+	  })
+	  return Promise.all(promises)
+	}
     return new Promise((resolve, reject) => {
-      this._flagCmd(flag, type, id, channel, reason, (err) => {
+      this._flagCmd(flag, type, channel, id, reason, (err) => {
         if (err) { return reject(err) }
         else { resolve() }
       })
     })
   }
 
-  // type should be either 'add' or 'remove'
+  // * type should be either 'add' or 'remove'. 
+  // * if cb not provided, a read-only stream is returned
   _flagCmd (flag, type, channel='@', id, reason='', cb) {
     const fname = (type === 'add' ? 'addFlags' : 'removeFlags')
     return this.core.moderation[fname]({


### PR DESCRIPTION
this pr adds
* `/actions` - list historic actions by you or your currently applied moderators
* `/roles` - shows the admins/mods you have applied atm
* new virtual message type: `chat/moderation` see https://github.com/cabal-club/cabal-cli/pull/192 for how it is used cc @nikolaiwarner 
* adds support for displaying realtime moderation actions by other moderators/admins, see cabal-cli pr above for what that looks like
* fixes a bug with setFlag, also reverts _setFlag to return a stream instead of promise
* fixes ordering of virtual messages (they weren't being sorted properly before)
* adds better user feedback for various moderation actions