### PR TITLE
add whisperlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "memdb": "^1.3.1",
     "mkdirp": "^1.0.4",
     "monotonic-timestamp": "0.0.9",
+    "paperslip": "^2.2.1",
     "pump": "^3.0.0",
     "qrcode": "^1.4.4",
     "random-access-memory": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "memdb": "^1.3.1",
     "mkdirp": "^1.0.4",
     "monotonic-timestamp": "0.0.9",
-    "paperslip": "^2.2.1",
+    "paperslip": "^3.0.0",
     "pump": "^3.0.0",
     "qrcode": "^1.4.4",
     "random-access-memory": "^3.1.1",

--- a/src/client.js
+++ b/src/client.js
@@ -167,7 +167,6 @@ class Client {
     if (typeof key === 'string') {
       key = key.trim()
       cabalPromise = this.resolveName(key).then((resolvedKey) => {
-          console.log("resolved key", resolvedKey)
         if (resolvedKey === null) {
           dnsFailed = true
           return

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,6 +2,7 @@ const qr = require('qrcode')
 const pump = require('pump')
 const to = require('to2')
 const strftime = require('strftime')
+const paperslip = require("paperslip")
 
 module.exports = {
   add: {
@@ -17,6 +18,23 @@ module.exports = {
           else res.end()
         })
       }
+    }
+  },
+  whisper: {
+    help: () => 'create a whisper link, a shortlived shortname alias for this cabal\'s key',
+    call: (cabal, res, arg) => {
+        if (arg === '') {
+            return res.error("you need to provide a shortname, e.g. 'workshop'")
+        }
+        const topic = `${arg}-${cabal.key.slice(0,3)}`
+        const whisperlink = `whisper://${topic}`
+        res.info("whispering on " + whisperlink + " for the next 5 minutes")
+        // currently this will logout ip addresses that join via the whisper key
+        const swarm = paperslip.write(topic, `cabal://${cabal.key}`, res.info) 
+        setTimeout(() => {
+            paperslip.stop(swarm)
+            res.info("stopped whispering " + topic)
+        }, 5 * 60 * 1000)
     }
   },
   new: {


### PR DESCRIPTION
Hi friends!

This PR adds _whisperlinks_. Whisperlinks are user defined, shortlived, shortname aliases for a cabal key. They look something like 
```
whisper://workshop-1ee
```
where the first part identifies the string as a whisper link, `workshop` is the user defined alias, and the `-1ee` suffix are three first hex characters of the cabal key being shared (which helps verify the joined cabal, as well as disambiguate names & prevent already-unlikely name collisions).

Whisperlinks are shortlived, currently terminating after 5 minutes. A whisperlink can be used multiple times before it self-terminates, and it will sync over LAN as well as the internet (it uses [hyperswarm](https://github.com/hyperswarm/hyperswarm), under the hood)

Anyone can create a whisperlink for a cabal they are in by invoking the `/whisper <name>` command.

The entire raison d'être of whisperlinks is that creating and sharing cabals in physical space was _really_ awkward before. If you had a workshop at a hackerspace, with everyone gathered locally, you practically had to use a separate chat software in order to transmit the 64 character long cabal key amongst the group. Now, someone could just create a whisperlink and verbally transmit the short & understandable alias they chose.

This PR uses a module I created a while back called [paperslip](https://github.com/cblgh/paperslip) to accomplish most of the not-so-heavy lifting.