### PR TITLE
Implement /search <term> (--ch <channel>)

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -120,10 +120,15 @@ module.exports = {
     help: () => 'search the backlog for messages; /search <term> (--ch <channel name>)',
     category: ["misc"],
     call: (cabal, res, arg) => {
-      if (arg.length === 0) return
+      if (!arg) { 
+        return res.error(`/search <term> (--ch <channel>)`)
+      }
       const opts = {}
       if (arg.indexOf("--ch") >= 0) {
         let [term, channel] = arg.split("--ch")
+        if (!term || term.length === 0) { 
+            return res.error(`/search <term> (--ch <channel>)`)
+        }
         term = term.trim()
         channel = channel.trim()
         if (!cabal.channels[channel]) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -116,6 +116,38 @@ module.exports = {
       })
     }
   },
+  search: {
+    help: () => 'search the backlog for messages; /search <term> (--ch <channel name>)',
+    category: ["misc"],
+    call: (cabal, res, arg) => {
+      if (arg.length === 0) return
+      const opts = {}
+      if (arg.indexOf("--ch") >= 0) {
+        let [term, channel] = arg.split("--ch")
+        term = term.trim()
+        channel = channel.trim()
+        if (!cabal.channels[channel]) {
+          res.error(`channel ${channel} does not exist`)
+          res.error(`/search <term> (--ch <channel>)`)
+          return 
+        }
+        opts.channel = channel.trim()
+        arg = term
+      }
+      cabal.client.searchMessages(arg, opts).then((matches) => {
+        const users = cabal.getUsers()
+        res.info(`${matches.length} matching ${matches.length === 1 ? "log" : "logs"} found`)
+        matches.forEach((envelope) => {
+          let { message } = envelope
+          if (message && message.value && message.value.type === "chat/text") {
+            const user = users[message.key].name || message.key.slice(0, 8)
+            const output = `<${user}> ${message.value.content.text}`
+            res.info(output)
+          }
+        })
+      })
+    }
+  },
   names: {
     help: () => 'display the names and unique ids of the cabal\'s peers',
     category: ["basics"],


### PR DESCRIPTION
This PR adds the `/search` command, which makes use of @timgoeller's [excellent search PR](https://github.com/cabal-club/cabal-client/pull/44).

The syntax at the moment is simple: `/search <term> (--ch <channel>)`. If `--ch` is omitted, the currently focused channel is searched.