### PR TITLE
sanitize resolved shortnames better, improve scrub

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "cabal-core": "^13.0.1",
+    "cabal-core": "^13.1.0",
     "collect-stream": "^1.2.1",
     "dat-dns": "^4.1.2",
     "debug": "^4.1.1",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -177,7 +177,7 @@ class CabalDetails extends EventEmitter {
       msg.content.channel = this.chname
     }
     // no typing to !status
-    if (msg.content.channel === "!status") return
+    if (msg.content.channel === "!status") return cb(new Error("not allowed to post to !status"), null) 
     if (!msg.type) msg.type = 'chat/text'
     this.core.publish(msg, opts, (err, m) => {
       this._emitUpdate('publish-message', { message: msg })
@@ -351,7 +351,7 @@ class CabalDetails extends EventEmitter {
         if (err) return cb(err)
         // we probably always want to open a joined channel?
         this.focusChannel(channel)
-        cb(null)
+        return cb(null)
       })
     } else nextTick(cb, null)
   }

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -176,6 +176,8 @@ class CabalDetails extends EventEmitter {
     if (!msg.content.channel) {
       msg.content.channel = this.chname
     }
+    // no typing to !status
+    if (msg.content.channel === "!status") return
     if (!msg.type) msg.type = 'chat/text'
     this.core.publish(msg, opts, (err, m) => {
       this._emitUpdate('publish-message', { message: msg })

--- a/src/commands.js
+++ b/src/commands.js
@@ -271,11 +271,35 @@ module.exports = {
       }
       const users = cabal.getUsers()
       const whoisKeys = Object.keys(users).filter((k) => users[k].name && users[k].name === arg)
+      if (whoisKeys.length === 0) {
+          res.info(`there's currently no one named ${arg}`)
+          res.end()
+          return
+      }
       res.info(`${arg}'s public keys:`)
       // list all of arg's public keys in list
       for (var key of whoisKeys) {
         res.info(`  ${key}`)
       }
+      res.end()
+    }
+  },
+  whoiskey: {
+    help: () => 'display the user associated with the passed in public key',
+    category: ["moderation", "misc"],
+    call: (cabal, res, arg) => {
+      if (!arg) {
+        res.info('usage: /whoiskey <public key>')
+        res.end()
+        return
+      }
+      arg = arg.trim().replace("\"", "")
+      const users = cabal.getUsers()
+      if (typeof users[arg] === "undefined") {
+        res.error("no user associated with key", arg)
+        return
+      }
+      res.info(`${arg} is currently known as: ${users[arg].name || "<unset nickname>"}`)
       res.end()
     }
   },


### PR DESCRIPTION
this pr solves some mistakes when resolving cabal keys that have an admin/mod key set. previously, the full length resolved uri would be used internally, instead of the properly scrubbed cabal key. this caused side effects, such as the screenshot, below.

![image](https://user-images.githubusercontent.com/3862362/104228837-b15eea00-544b-11eb-8a34-77b46b7506a2.png)
_there should only be one folder, and it should not be the one with an admin key stuck in it_

this pr also adds a `/whoiskey <public key>` command that lets you know what the user name is of that public key.
i needed it for some other debugging and i cba to add a separate pr ^^'


