### PR TITLE
Desktop friendly command events

### DIFF
--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -121,12 +121,10 @@ class CabalDetails extends EventEmitter {
     var m = /^\/\s*(\w+)(?:\s+(.*))?/.exec(line.trimRight())
     if (m && this._commands[m[1]] && typeof this._commands[m[1]].call === 'function') {
       this._commands[m[1]].call(this, this._res(m[1]), m[2])
-      this._emitUpdate('command', { command: m[1], arg: m[2] || '' })
     } else if (m && this._aliases[m[1]]) {
       var key = this._aliases[m[1]]
       if (this._commands[key]) {
         this._commands[key].call(this, this._res(key), m[2])
-        this._emitUpdate('command', { command: key, arg: m[2] || '' })
       } else {
         this._res("warn").info(`command for alias ${m[1]} => ${key} not found`)
         cb()

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -53,14 +53,17 @@ class CabalDetails extends EventEmitter {
     this.client = client
     this._commands = commands || {}
     this._aliases = aliases || {}
-    this._res = function (type) {
-      let seqno = 0
+    /* _res takes a type (cabal event typeas a string) and returns an object with the functions: info, error, end */
+    this._res = function (type) { // type: the type of event to emit (e.g. channel-join, new-message, topic etc)
+      let seqno = 0 // tracks # of sent info messages
       return {
         info: (msg, obj) => {
           let payload = (typeof msg === "string") ? { text: msg } : { ...msg }
-          if (typeof obj !== "undefined") payload === { ...payload, ...obj }
+          if (typeof obj !== "undefined") payload = { ...payload, ...obj }
+
           payload["command"] = type
           payload["seqno"] = seqno++
+
           this._emitUpdate('info', payload)
         },
         error: (err) => {

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -54,10 +54,13 @@ class CabalDetails extends EventEmitter {
     this._commands = commands || {}
     this._aliases = aliases || {}
     this._res = function (type) {
+      let seqno = 0
       return {
-        info: (msg) => {
-          const payload = (typeof msg === "string") ? { text: msg } : { ...msg }
+        info: (msg, obj) => {
+          let payload = (typeof msg === "string") ? { text: msg } : { ...msg }
+          if (typeof obj !== "undefined") payload === { ...payload, ...obj }
           payload["command"] = type
+          payload["seqno"] = seqno++
           this._emitUpdate('info', payload)
         },
         error: (err) => {

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -56,7 +56,7 @@ class CabalDetails extends EventEmitter {
     this._res = function (type) {
       return {
         info: (msg) => {
-          const payload = { ...msg }
+          const payload = (typeof msg === "string") ? { text: msg } : { ...msg }
           payload["command"] = type
           this._emitUpdate('info', payload)
         },

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -29,6 +29,7 @@ class CabalDetails extends EventEmitter {
    * @constructor
    * @fires CabalDetails#update
    * @fires CabalDetails#init
+   * @fires CabalDetails#info
    * @fires CabalDetails#user-updated
    * @fires CabalDetails#new-channel
    * @fires CabalDetails#new-message
@@ -550,6 +551,14 @@ class CabalDetails extends EventEmitter {
    *
    * Fires when any kind of change has happened to the cabal.
    * @event CabalDetails#update
+   */
+
+  /**
+   *
+   * Fires when a valid slash-command (/<command>) emits output. See src/commands.js for all commands & their payloads.
+   * @event CabalDetails#info
+   * @type {object}
+   * @property {string} command - The command that triggered the event & has emitted output
    */
 
   _emitUpdate (type, payload = null) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -164,11 +164,11 @@ module.exports = {
       var users = cabal.getUsers()
       var userkeys = Object.keys(users).map((key) => users[key]).sort(cmpUser)
       res.info('history of peers in cabal')
-      userkeys.map((u) => {
+      userkeys.map((u, i) => {
         var username = u.name || 'conspirator'
         var spaces = ' '.repeat(15)
         var paddedName = (username + spaces).slice(0, spaces.length)
-        res.info(`  ${paddedName} ${u.key}`)
+        res.info(`${i+1}.  ${paddedName} ${u.key}`)
       })
     }
   },

--- a/src/commands.js
+++ b/src/commands.js
@@ -31,14 +31,16 @@ module.exports = {
         }
         const topic = `${arg}-${cabal.key.slice(0,3)}`
         const link = `whisper://${topic}`
-        res.info({ text: `whispering on ${link} for the next 5 minutes`, link })
+        const minutes = 5
+        const ttl = minutes * 60 * 1000 // time to live (how long the link is active)
+        res.info({ text: `whispering on ${link} for the next ${minutes} minutes`, link, ttl })
         // NOTE: currently this will log which ip addresses join via the whisperlink
         const swarm = paperslip.write(topic, `cabal://${cabal.key}`, res.info) 
         setTimeout(() => {
             paperslip.stop(swarm)
             res.info(`stopped whispering ${link}`)
             res.end()
-        }, 5 * 60 * 1000)
+        }, ttl)
     }
   },
   new: {

--- a/src/commands.js
+++ b/src/commands.js
@@ -3,6 +3,7 @@ const pump = require('pump')
 const to = require('to2')
 const strftime = require('strftime')
 const paperslip = require("paperslip")
+const hrinames = require("human-readable-ids").hri // transitive dep via paperslip
 
 module.exports = {
   add: {
@@ -25,17 +26,18 @@ module.exports = {
     help: () => 'create a whisper link, a shortlived shortname alias for this cabal\'s key',
     category: ["sharing"],
     call: (cabal, res, arg) => {
-        if (arg === '') {
-            return res.error("you need to provide a shortname, e.g. 'workshop'")
+        if (typeof arg === "undefined" || arg === '') {
+            arg = hrinames.random()
         }
         const topic = `${arg}-${cabal.key.slice(0,3)}`
-        const whisperlink = `whisper://${topic}`
-        res.info("whispering on " + whisperlink + " for the next 5 minutes")
-        // currently this will logout ip addresses that join via the whisper key
+        const link = `whisper://${topic}`
+        res.info({ text: `whispering on ${link} for the next 5 minutes`, link })
+        // NOTE: currently this will log which ip addresses join via the whisperlink
         const swarm = paperslip.write(topic, `cabal://${cabal.key}`, res.info) 
         setTimeout(() => {
             paperslip.stop(swarm)
-            res.info("stopped whispering " + topic)
+            res.info(`stopped whispering ${link}`)
+            res.end()
         }, 5 * 60 * 1000)
     }
   },

--- a/src/commands.js
+++ b/src/commands.js
@@ -182,7 +182,6 @@ module.exports = {
         var userPart = count ? `: ${count} ${count === 1 ? 'person' : 'people'}` : ''
         res.info({
           text: `  ${joinedChannels.includes(c) ? '*' : ' '} ${c}${userPart} ${shortTopic}`,
-          command: "channels",
           channel: c,
           userCount: count,
           topic,


### PR DESCRIPTION
This PR makes all slash commands' `info` event also include **which command** triggered the event. As a consequence, handling command output in react-style apps like cabal-desktop should be a lot easier and [less haphazard](https://github.com/cabal-club/cabal-desktop/blob/master/app/actions.js#L623-L631).

`CabalDetails._res` has been converted from being an object, returning three functions (`info`, `error`, `end`), to a function. The function takes the command type as an argument, and calling it returns the same object as previously—the key difference being that the three functions have had their **payload annotated to include the command type**. 

(n.b. This is not _entirely_ correct, as only `info` has been annotated to include the `command` key,)

The emitted `command` event has also been removed, as it was unused in most places I can see cabal-client being used (I checked desktop, cli & timgoeller's bot framework).

@nikolaiwarner @khubo lmk if this doesn't make sense (i think it should tho?)