### PR TITLE
Channel-specific moderation actions

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -739,7 +739,7 @@ function flagCmd (cmd, cabal, res, arg) {
 
   const peerName = getPeerName(cabal, id)
   const placeModifier = channel === "@" ? "for the entire cabal" : `in channel ${channel}`
-	if (['admin', 'mod'].includes(flag)) {
+  if (['admin', 'mod'].includes(flag)) {
     if (/^un/.test(cmd) && flag === 'mod' && !cabal.users[id].isModerator(channel)) {
       return res.error(`${peerName} is not a mod ${placeModifier}`)
     } else if (/^un/.test(cmd) && flag === 'admin' && !cabal.users[id].isAdmin(channel)) {
@@ -749,7 +749,7 @@ function flagCmd (cmd, cabal, res, arg) {
     } else if (!/^un/.test(cmd) && flag === 'admin' && cabal.users[id].isAdmin(channel)) {
       return res.error(`${peerName} is already an admin ${placeModifier}`)
     }
-	} else {
+  } else {
     if (/^un/.test(cmd)) {
       if (!cabal.users[id].isHidden(channel)) {
         return res.error(`cannot unhide ${peerName}: they are not hidden`)
@@ -759,7 +759,7 @@ function flagCmd (cmd, cabal, res, arg) {
         return res.error(`${peerName} is already hidden`)
       }
     }
-	}
+  }
 
   cabal.moderation.setFlag(flag, type, channel, id, reason).then(() => {
     res.end()

--- a/src/moderation.js
+++ b/src/moderation.js
@@ -65,14 +65,14 @@ class Moderation {
   setFlag (flag, type, channel = '@', id, reason = '') {
     // a list of [[id, reason]] was passed in
     if (typeof id === 'object' && typeof id[Symbol.iterator] === 'function') {
-	  const promises = id.map((entry) => {
+      const promises = id.map((entry) => {
         return new Promise((resolve, reject) => {
-		  this._flagCmd(flag, type, channel, entry[0], entry[1], (err) => {
+          this._flagCmd(flag, type, channel, entry[0], entry[1], (err) => {
             if (err) { return reject(err) } else { resolve() }
-		  })
+          })
         })
-	  })
-	  return Promise.all(promises)
+      })
+      return Promise.all(promises)
     }
     return new Promise((resolve, reject) => {
       this._flagCmd(flag, type, channel, id, reason, (err) => {


### PR DESCRIPTION
When this PR is finished+merged, we will have full support for taking moderation actions in specific channels (as opposed to the broader cabal).

Before this PR, the syntax for e.g. hiding was:
```
/hide <person.suffix> <reason string>
```

After this PR, the above will still be supported, as well as extended to allow:
```
/hide <person.suffix> --reason <reason string> --channel <channel name>
```

I am currently mulling over allowing multiple --channel options in a single command:

```
/ hide <person.suffix> --reason <reason string> --channel ch1 --channel ch2 --channel ch3
```

You can also omit either flag (--reason, --channel) and it will still work.