### PR TITLE
Channel archiving

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "cabal-core": "^13.1.0",
+    "cabal-core": "^13.2.0",
     "collect-stream": "^1.2.1",
     "dat-dns": "^4.1.2",
     "debug": "^4.1.1",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -277,7 +277,7 @@ class CabalDetails extends EventEmitter {
 
   /**
    * @param {object} [opts]
-   * @property {boolean} archived - Determines whether to include archived channels or not. Defaults to false.
+   * @property {boolean} includeArchived - Determines whether to include archived channels or not. Defaults to false.
    * * @returns {string[]} a list of all the channels in this cabal. Does not return channels with 0 members.
    */
   getChannels (opts) {
@@ -410,6 +410,66 @@ class CabalDetails extends EventEmitter {
         cb(null)
       })
     }
+  }
+
+  /**
+   * Archive a channel. Publishes a message announcing
+   * that you have archived the channel, applying it to the views of others who have you as a moderator/admin.
+   * @param {string} channel
+   * @param {string} [reason]
+   * @param {function} cb - callback invoked when the operation has finished, with error as its only parameter
+   */
+  archive (channel, reason = "", cb) {
+    if (!cb) cb = noop
+    const details = this.channels[channel]
+
+    if (channel === '!status') {
+      return nextTick(cb, new Error('cannot archive the !status channel'))
+    }
+    if (!details) {
+      return nextTick(cb, new Error('cannot archive non-existent channel'))
+    }
+    this.channels[channel].archive()
+    this.publishMessage({
+      type: 'channel/archive',
+      content: {
+        channel,
+        reason
+      }
+    }, {}, (err) => {
+      if (err) cb(err)
+      else cb()
+    })
+  }
+
+  /**
+   * Unarchive a channel. Publishes a message announcing
+   * that you have unarchived the channel.
+   * @param {string} channel
+   * @param {string} [reason]
+   * @param {function} cb - callback invoked when the operation has finished, with error as its only parameter
+   */
+  unarchive (channel, reason = "", cb) {
+    if (!cb) cb = noop
+    const details = this.channels[channel]
+
+    if (channel === '!status') {
+      return nextTick(cb, new Error('cannot unarchive the !status channel'))
+    }
+    if (!details) {
+      return nextTick(cb, new Error('cannot unarchive non-existent channel'))
+    }
+    this.channels[channel].unarchive()
+    this.publishMessage({
+      type: 'channel/unarchive',
+      content: {
+        channel,
+        reason
+      }
+    }, {}, (err) => {
+      if (err) cb(err)
+      else cb()
+    })
   }
 
   /**

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -419,7 +419,7 @@ class CabalDetails extends EventEmitter {
    * @param {string} [reason]
    * @param {function} cb - callback invoked when the operation has finished, with error as its only parameter
    */
-  archive (channel, reason = "", cb) {
+  archiveChannel (channel, reason = "", cb) {
     if (!cb) cb = noop
     const details = this.channels[channel]
 
@@ -449,7 +449,7 @@ class CabalDetails extends EventEmitter {
    * @param {string} [reason]
    * @param {function} cb - callback invoked when the operation has finished, with error as its only parameter
    */
-  unarchive (channel, reason = "", cb) {
+  unarchiveChannel (channel, reason = "", cb) {
     if (!cb) cb = noop
     const details = this.channels[channel]
 
@@ -470,6 +470,11 @@ class CabalDetails extends EventEmitter {
       if (err) cb(err)
       else cb()
     })
+  }
+
+  isChannelArchived(channel) {
+    if (!this.channels[channel]) return false
+    return this.channels[channel].archived
   }
 
   /**
@@ -735,7 +740,7 @@ class CabalDetails extends EventEmitter {
     // notify when a user has archived a channel
     this.registerListener(cabal.archives.events, 'archive', (channel, reason, key) => {
       const user = this.users[key]
-      if (key !== this.user.key && (!user || (!user.isModerator() && !user.isAdmin()))) { return }
+      if (key !== this.user.key && (!user || !user.canModerate())) { return }
       if (!this.channels[channel]) {
         this.channels[channel] = new ChannelDetails(this.core, channel)
       }
@@ -746,7 +751,7 @@ class CabalDetails extends EventEmitter {
     // notify when a user has restored an archived channel
     this.registerListener(cabal.archives.events, 'unarchive', (channel, reason, key) => {
       const user = this.users[key]
-      if (key !== this.user.key && (!user || (!user.isModerator() && !user.isAdmin()))) { return }
+      if (key !== this.user.key && (!user || !user.canModerate())) { return }
       if (!this.channels[channel]) {
         this.channels[channel] = new ChannelDetails(this.core, channel)
       }

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -7,6 +7,7 @@ const pump = require('pump')
 const Moderation = require('./moderation')
 const timestamp = require('monotonic-timestamp')
 const collect = require('collect-stream')
+const init = require('./initialization-callbacks')
 const { nextTick } = process
 
 /**
@@ -694,52 +695,62 @@ class CabalDetails extends EventEmitter {
 
   _initialize (done) {
     const cabal = this.core
-    cabal.archives.get((err, archivedChannels) => {
-      // populate channels
-      cabal.channels.get((err, channels) => {
-        channels.forEach((channel) => {
-          const details = this.channels[channel]
-          if (!details) {
-            this.channels[channel] = new ChannelDetails(cabal, channel)
-          }
-          // mark archived channels as such
-          if (archivedChannels.indexOf(channel) >= 0) {
-            this.channels[channel].archive()
-          }
-          // listen for updates that happen within the channel
-          cabal.messages.events.on(channel, this.messageListener.bind(this))
+    let finished = 0
+    let asyncBlocks = 0
 
-          // add all users joined to a channel
-          cabal.memberships.getUsers(channel, (err, users) => {
-            users.forEach((u) => this.channels[channel].addMember(u))
-          })
+    this._finish = () => {
+      finished += 1
+      if (finished >= asyncBlocks) done()
+    }
 
-          // for each channel, get the topic
-          cabal.topics.get(channel, (err, topic) => {
-            this.channels[channel].topic = topic || ''
-          })
-        })
+    const invoke = (self, fn, cb) => {
+      asyncBlocks += 1
+      // the line below converts (as an example): 
+      //    invoke(cabal.archives, "get", init.getArchivesCallback)
+      // into: 
+      //    cabal.archives.get(getArchivesCallback)
+      // with proper `this` arguments for the respectively called functions
+      self[fn].bind(self)(cb.bind(this))
+    }
+
+    /* invoke one-time functions to populate & initialize the local state from data on disk */
+    invoke(cabal.archives, "get", init.getArchivesCallback)
+    invoke(cabal, "getLocalKey", init.getLocalKeyCallback)
+    invoke(cabal.users, "getAll", init.getAllUsersCallback)
+
+    /* register all the listeners we'll be using */
+    this.registerListener(cabal.users.events, 'update', (key) => {
+      cabal.users.get(key, (err, user) => {
+        if (err) return
+        this.users[key] = new User(Object.assign(this.users[key] || {}, user))
+        if (this.user && key === this.user.key) this.user = this.users[key]
+        this._emitUpdate('user-updated', { key, user })
       })
     })
 
-    cabal.getLocalKey((err, lkey) => {
-      cabal.memberships.getMemberships(lkey, (err, channels) => {
-        if (channels.length === 0) {
-          // make `default` the first channel if no saved state exists
-          this.joinChannel('default')
-        }
-        for (const channel of channels) {
-          // it's possible to be joined to a channel that `cabal.channels.get` doesn't return
-          // (it's an empty channel, with no messages)
-          const details = this.channels[channel]
-          if (!details) {
-            this.channels[channel] = new ChannelDetails(cabal, channel)
-            // listen for updates that happen within the channel
-            cabal.messages.events.on(channel, this.messageListener.bind(this))
-          }
-          this.channels[channel].joined = true
-        }
+    this.registerListener(cabal.topics.events, 'update', (msg) => {
+      var { channel, text } = msg.value.content
+      if (!this.channels[channel]) { this.channels[channel] = new ChannelDetails(this.core, channel) }
+      this.channels[channel].topic = text || ''
+      this._emitUpdate('topic', { channel, topic: text || '' })
+    })
+
+    this.registerListener(cabal, 'peer-added', (key) => {
+      if (this.users[key]) {
+        this.users[key].online = true
+      } else {
+        this.users[key] = new User({ key, online: true })
+      }
+      this._emitUpdate('started-peering', { key, name: this.users[key].name || key })
+    })
+
+    this.registerListener(cabal, 'peer-dropped', (key) => {
+      Object.keys(this.users).forEach((k) => {
+        if (k === key) {
+          this.users[k].online = false
+        } 
       })
+      this._emitUpdate('stopped-peering', { key, name: this.users[key].name || key })
     })
 
     // notify when a user has archived a channel
@@ -794,133 +805,6 @@ class CabalDetails extends EventEmitter {
       // Calls fn with every new message that arrives in channel.
       cabal.messages.events.on(channel, this.messageListener.bind(this))
       this._emitUpdate('new-channel', { channel })
-    })
-
-    // Load moderation state
-    const loadModerationState = (cb) => {
-      cabal.moderation.list((err, list) => {
-        if (err) return cb(err)
-        list.forEach(info => {
-          const user = this.users[info.id]
-          if (user) user.flags.set(info.channel, info.flags)
-        })
-        cb()
-      })
-    }
-
-    cabal.users.getAll((err, users) => {
-      if (err) return
-      this.users = new Map()
-      Object.keys(users).forEach(key => {
-        this.users[key] = new User(users[key])
-	  })
-	  this._initializeLocalUser(() => {
-        loadModerationState(() => {
-          this.registerListener(cabal.moderation.events, 'update', (info) => {
-            let user = this.users[info.id]
-            let changedRole = {}
-            if (!user) {
-              const flags = new Map()
-              flags.set(info.group, info.flags)
-              user = new User({ key: info.id, flags: flags })
-              this.users[info.id] = user
-            } else {
-              changedRole = { mod: user.isModerator(), admin: user.isAdmin(), hidden: user.isHidden() }
-              user.flags.set(info.group, info.flags)
-              changedRole.mod = changedRole.mod != user.isModerator()
-              changedRole.admin = changedRole.admin != user.isAdmin()
-              changedRole.hidden = changedRole.hidden != user.isHidden()
-            }
-            const issuer = this.users[info.by]
-            if (!issuer) return
-
-            this.core.getMessage(info.key, (err, doc) => {
-              const issuerName = issuer.name || info.by.slice(0, 8)
-              const role = doc.content.flags[0]
-              const reason = doc.content.reason || ''
-
-              // there was no change in behaviour, e.g. someone modded an already
-              // modded person, hid someone that was already hidden
-              const changeOccurred = Object.keys(changedRole).filter(r => changedRole[r]).length > 0
-              if (!changeOccurred) {
-                this._emitUpdate('user-updated', { key: info.id, user })
-                return
-              }
-              const type = doc.type.replace(/^flags\//, '')
-              let action, text
-              if (['admin', 'mod'].includes(role)) { action = (type === 'add' ? 'added' : 'removed') }
-              if (role === 'hide') { action = (type === 'add' ? 'hid' : 'unhid') }
-              if (role === 'hide') {
-                text = `${issuerName} ${action} ${user.name} ${reason}`
-              } else {
-                text = `${issuerName} ${action} ${user.name} as ${role} ${reason}`
-              }
-              const obj = { issuer: info.by, receiver: info.id, role, type, reason }
-              this._emitUpdate('user-updated', { key: info.id, user })
-
-              const msg = {
-                key: '!status',
-                value: {
-                  timestamp: timestamp(),
-                  type: 'chat/moderation',
-                  content: {
-                    text,
-                    issuerid: info.by,
-                    receiverid: info.id,
-                    role,
-                    type,
-                    reason
-                  }
-                }
-              }
-
-              // add to !status channel, to have a canonical log of all moderation actions in one place
-              this.addStatusMessage(msg, '!status')
-
-              // also add to the currently focused channel, so that the moderation action isn't missed
-              if (this.chname !== '!status') {
-                this.addStatusMessage(msg)
-              }
-            })
-          })
-
-          done()
-        })
-      })
-
-      this.registerListener(cabal.users.events, 'update', (key) => {
-        cabal.users.get(key, (err, user) => {
-          if (err) return
-          this.users[key] = new User(Object.assign(this.users[key] || {}, user))
-          if (this.user && key === this.user.key) this.user = this.users[key]
-          this._emitUpdate('user-updated', { key, user })
-        })
-      })
-
-      this.registerListener(cabal.topics.events, 'update', (msg) => {
-        var { channel, text } = msg.value.content
-        if (!this.channels[channel]) { this.channels[channel] = new ChannelDetails(this.core, channel) }
-        this.channels[channel].topic = text || ''
-        this._emitUpdate('topic', { channel, topic: text || '' })
-      })
-
-      this.registerListener(cabal, 'peer-added', (key) => {
-        if (this.users[key]) {
-          this.users[key].online = true
-        } else {
-          this.users[key] = new User({ key, online: true })
-        }
-        this._emitUpdate('started-peering', { key, name: this.users[key].name || key })
-      })
-
-      this.registerListener(cabal, 'peer-dropped', (key) => {
-        Object.keys(this.users).forEach((k) => {
-          if (k === key) {
-            this.users[k].online = false
-          }
-        })
-        this._emitUpdate('stopped-peering', { key, name: this.users[key].name || key })
-      })
     })
   }
 }

--- a/src/channel-details.js
+++ b/src/channel-details.js
@@ -8,6 +8,8 @@ class ChannelDetailsBase {
 
     this.members = new Set()
     this.mentions = []
+    /* archived channels are not visible in channel listings */
+    this.archived = false
     this.virtualMessages = []
     this.newMessageCount = 0
     this.datesSeen = new Set()
@@ -23,6 +25,14 @@ class ChannelDetailsBase {
 
   toString () {
     return this.name
+  }
+
+  archive () {
+    this.archived = true
+  }
+
+  unarchive () {
+    this.archived = false
   }
 
   addMember (key) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -98,7 +98,7 @@ module.exports = {
         res.info("no channels are archived")
       } else {
         archivedChannels.forEach(channel => {
-          res.info(channel)
+          res.info(`  ${channel}`, { channel })
         })
       }
 
@@ -108,7 +108,7 @@ module.exports = {
           res.info("there are no restored channels. restore an archived channel with /unarchive <channel name>")
         } else {
           unarchivedChannels.forEach(channel => {
-            res.info(channel)
+              res.info(`  ${channel}`, { channel })
           })
         }
         res.end()

--- a/src/commands.js
+++ b/src/commands.js
@@ -22,6 +22,73 @@ module.exports = {
       }
     }
   },
+  archive: {
+    help: () => 'archive a channel',
+    category: ["channels"],
+    call: (cabal, res, arg) => {
+      const reason = "" // TODO: force --reason flag if adding reason?
+      if (typeof arg === "undefined" || arg.length <= 0) {
+        return res.error("you need to specify the channel to archive")
+      } else if (typeof cabal.channels[arg] === "undefined") {
+        return res.error(`${arg} does not exist`)
+      } else if (arg === "!status") {
+        res.error("the !status channel cannot be archived")
+      }
+      res.info(`archiving ${arg}`)
+      cabal.publishMessage({
+        type: 'channel/archive',
+        content: {
+          channel: arg,
+          reason
+        }
+      }, {}, (err) => {
+        if (err) res.error(err)
+        else res.end()
+      })
+    }
+  },
+  unarchive: {
+    help: () => 'unarchive a channel',
+    category: ["channels"],
+    alias: ['restore'],
+    call: (cabal, res, arg) => {
+      const reason = "" // TODO
+      if (typeof arg === "undefined" || arg.length <= 0) {
+        return res.error("you need to specify the channel to unarchive")
+      } else if (typeof cabal.channels[arg] === "undefined") {
+        return res.error(`${arg} does not exist`)
+      } else if (arg === "!status") {
+        res.error("the !status channel cannot be archived (and so neither unarchived)")
+      }
+      res.info(`unarchiving ${arg}`)
+      cabal.publishMessage({
+        type: 'channel/unarchive',
+        content: {
+          channel: arg,
+          reason
+        }
+      }, {}, (err) => {
+        if (err) res.error(err)
+        else res.end()
+      })
+    }
+  },
+  archives: {
+    help: () => 'list the currently archived channels',
+    category: ["channels"],
+    alias: ["archived"],
+    call: (cabal, res, arg) => {
+      const archivedChannels = cabal.getChannels({ includeArchived: true }).filter(ch => cabal.channels[ch].archived)
+      if (archivedChannels.length === 0) {
+        res.info("no channels are archived")
+      } else {
+        res.info("archived channels:")
+        archivedChannels.forEach(channel => {
+          res.info(channel)
+        })
+      }
+    }
+  },
   whisper: {
     help: () => 'create a whisper link, a shortlived shortname alias for this cabal\'s key',
     category: ["sharing"],

--- a/src/commands.js
+++ b/src/commands.js
@@ -35,7 +35,7 @@ module.exports = {
         res.error("the !status channel cannot be archived")
       }
       res.info(`archiving ${arg}`)
-      cabal.archive(arg, reason, (err) => {
+      cabal.archiveChannel(arg, reason, (err) => {
         if (err) res.error(err)
         else res.end()
       })
@@ -55,7 +55,7 @@ module.exports = {
         res.error("the !status channel cannot be archived (and so neither unarchived)")
       }
       res.info(`unarchiving ${arg}`)
-      cabal.unarchive(arg, reason, (err) => {
+      cabal.unarchiveChannel(arg, reason, (err) => {
         if (err) res.error(err)
         else res.end()
       })
@@ -67,6 +67,7 @@ module.exports = {
     alias: ["archived"],
     call: (cabal, res, arg) => {
       const archivedChannels = cabal.getChannels({ includeArchived: true }).filter(ch => cabal.channels[ch].archived)
+
       res.info("all archived channels:")
       if (archivedChannels.length === 0) {
         res.info("no channels are archived")
@@ -75,10 +76,11 @@ module.exports = {
           res.info(channel)
         })
       }
+
       cabal.core.archives.getUnarchived(cabal.user.key, (err, unarchivedChannels) => {
-        res.info("your unarchived channels:")
+        res.info("channels you have restored:")
         if (unarchivedChannels.length === 0) {
-          res.info("no channels are unarchived")
+          res.info("there are no restored channels. restore an archived channel with /unarchive <channel name>")
         } else {
           unarchivedChannels.forEach(channel => {
             res.info(channel)

--- a/src/commands.js
+++ b/src/commands.js
@@ -412,6 +412,7 @@ module.exports = {
       res.info('moderation commands')
       res.info('\nbasic actions. the basic actions will be published to your log')
       res.info('USAGE /<cmd> NICK{.PUBKEY} {REASON...}')
+      res.info('      /<cmd> NICK{.PUBKEY} --channel <channel name> --reason <reason>')
       baseCmds.forEach((base) => {
         res.info(`/${base}: ${module.exports[base].help()}`)
         const reverse = `un${base}`

--- a/src/commands.js
+++ b/src/commands.js
@@ -819,7 +819,7 @@ function flagCmd (cmd, cabal, res, arg) {
 
   let { channel, reason } = extractChannelReasonOptions(options, "@", options) // if --channel option missin: assume default channel is '@' 
 
-  if (channel != "@" && typeof cabal.channels[channel] === "undefined") {
+  if (channel !== "@" && typeof cabal.channels[channel] === "undefined") {
     return res.error(`channel ${channel} does not exist`)
   }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -35,13 +35,7 @@ module.exports = {
         res.error("the !status channel cannot be archived")
       }
       res.info(`archiving ${arg}`)
-      cabal.publishMessage({
-        type: 'channel/archive',
-        content: {
-          channel: arg,
-          reason
-        }
-      }, {}, (err) => {
+      cabal.archive(arg, reason, (err) => {
         if (err) res.error(err)
         else res.end()
       })
@@ -61,13 +55,7 @@ module.exports = {
         res.error("the !status channel cannot be archived (and so neither unarchived)")
       }
       res.info(`unarchiving ${arg}`)
-      cabal.publishMessage({
-        type: 'channel/unarchive',
-        content: {
-          channel: arg,
-          reason
-        }
-      }, {}, (err) => {
+      cabal.unarchive(arg, reason, (err) => {
         if (err) res.error(err)
         else res.end()
       })

--- a/src/initialization-callbacks.js
+++ b/src/initialization-callbacks.js
@@ -1,0 +1,154 @@
+const { ChannelDetails } = require('./channel-details')
+const User = require('./user')
+/* this file contains callbacks used for populating the initial state. these are all invoked inside
+ * CabalDetails._initialize. once all the callbacks have finished, cabal-client is ready to be used & queried.
+ *
+ * each callback calls this._finish() to signal it is done.
+ */
+module.exports.getArchivesCallback = function (err, archivedChannels) {
+  const cabal = this.core
+  // populate channels
+  cabal.channels.get((err, channels) => {
+    channels.forEach((channel) => {
+      const details = this.channels[channel]
+      if (!details) {
+        this.channels[channel] = new ChannelDetails(cabal, channel)
+      }
+      // mark archived channels as such
+      if (archivedChannels.indexOf(channel) >= 0) {
+        this.channels[channel].archive()
+      }
+      // listen for updates that happen within the channel
+      cabal.messages.events.on(channel, this.messageListener.bind(this))
+
+      // add all users joined to a channel
+      cabal.memberships.getUsers(channel, (err, users) => {
+        users.forEach((u) => this.channels[channel].addMember(u))
+      })
+
+      // for each channel, get the topic
+      cabal.topics.get(channel, (err, topic) => {
+        this.channels[channel].topic = topic || ''
+      })
+    })
+
+    this._finish()
+  })
+}
+
+module.exports.getLocalKeyCallback = function (err, lkey) {
+  const cabal = this.core
+  cabal.memberships.getMemberships(lkey, (err, channels) => {
+    if (channels.length === 0) {
+      // make `default` the first channel if no saved state exists
+      this.joinChannel('default')
+    }
+    for (const channel of channels) {
+      // it's possible to be joined to a channel that `cabal.channels.get` doesn't return
+      // (it's an empty channel, with no messages)
+      const details = this.channels[channel]
+      if (!details) {
+        this.channels[channel] = new ChannelDetails(cabal, channel)
+        // listen for updates that happen within the channel
+        cabal.messages.events.on(channel, this.messageListener.bind(this))
+      }
+      this.channels[channel].joined = true
+    }
+    this._finish()
+  })
+}
+
+module.exports.getAllUsersCallback = function (err, users) {
+  const cabal = this.core
+  if (err) return
+  this.users = new Map()
+  Object.keys(users).forEach(key => {
+    this.users[key] = new User(users[key])
+  })
+
+  // Load moderation state
+  const loadModerationState = (cb) => {
+    cabal.moderation.list((err, list) => {
+      if (err) return cb(err)
+      list.forEach(info => {
+        const user = this.users[info.id]
+        if (user) user.flags.set(info.channel, info.flags)
+      })
+      cb()
+    })
+  }
+
+  this._initializeLocalUser(() => {
+    loadModerationState(() => {
+      this.registerListener(cabal.moderation.events, 'update', (info) => {
+        let user = this.users[info.id]
+        let changedRole = {}
+        if (!user) {
+          const flags = new Map()
+          flags.set(info.group, info.flags)
+          user = new User({ key: info.id, flags: flags })
+          this.users[info.id] = user
+        } else {
+          changedRole = { mod: user.isModerator(), admin: user.isAdmin(), hidden: user.isHidden() }
+          user.flags.set(info.group, info.flags)
+          changedRole.mod = changedRole.mod != user.isModerator()
+          changedRole.admin = changedRole.admin != user.isAdmin()
+          changedRole.hidden = changedRole.hidden != user.isHidden()
+        }
+        const issuer = this.users[info.by]
+        if (!issuer) return
+
+        this.core.getMessage(info.key, (err, doc) => {
+          const issuerName = issuer.name || info.by.slice(0, 8)
+          const role = doc.content.flags[0]
+          const reason = doc.content.reason || ''
+
+          // there was no change in behaviour, e.g. someone modded an already
+          // modded person, hid someone that was already hidden
+          const changeOccurred = Object.keys(changedRole).filter(r => changedRole[r]).length > 0
+          if (!changeOccurred) {
+            this._emitUpdate('user-updated', { key: info.id, user })
+            return
+          }
+          const type = doc.type.replace(/^flags\//, '')
+          let action, text
+          if (['admin', 'mod'].includes(role)) { action = (type === 'add' ? 'added' : 'removed') }
+          if (role === 'hide') { action = (type === 'add' ? 'hid' : 'unhid') }
+          if (role === 'hide') {
+            text = `${issuerName} ${action} ${user.name} ${reason}`
+          } else {
+            text = `${issuerName} ${action} ${user.name} as ${role} ${reason}`
+          }
+          const obj = { issuer: info.by, receiver: info.id, role, type, reason }
+          this._emitUpdate('user-updated', { key: info.id, user })
+
+          const msg = {
+            key: '!status',
+            value: {
+              timestamp: timestamp(),
+              type: 'chat/moderation',
+              content: {
+                text,
+                issuerid: info.by,
+                receiverid: info.id,
+                role,
+                type,
+                reason
+              }
+            }
+          }
+
+          // add to !status channel, to have a canonical log of all moderation actions in one place
+          this.addStatusMessage(msg, '!status')
+
+          // also add to the currently focused channel, so that the moderation action isn't missed
+          if (this.chname !== '!status') {
+            this.addStatusMessage(msg)
+          }
+        })
+      })
+
+      this._finish()
+    })
+  })
+}

--- a/src/user.js
+++ b/src/user.js
@@ -25,6 +25,11 @@ class User {
     const all = this.flags.get('@')
     return (chan && chan.includes('mod')) || (all && all.includes('mod'))
   }
+
+  canModerate(channel) {
+    return this.isAdmin(channel) || this.isModerator(channel)
+  }
+
 }
 
 module.exports = User


### PR DESCRIPTION
This PR adds implements support for channel archiving, enabling people to hide channels from being listed. This can be useful for abuse mitigation as well as handling mistakenly created channels, or cleaning up unused ones.

The system is centered around the subjective moderation system. This means that:
1. the local user can always archive/restore channels (you are always an admin from your own perspective)
2. the local user's moderators and admins will have their archiving actions be applied to the local user's view
3. if rando mcrando archives a channel, it will have no effect for the local user (unless the above applies)
4. people can still join & talk in archived channels, they will just be hidden from channel listings

Currently implemented commands:
```
/archives, /archived
    view the list of currently archived channels
/archive <channel name>
    archive <channel name>
/unarchive, /restore <channel name>
    restore <channel name> from the archives
```

This closes #68  and is related to #16. It is also dependent on merging https://github.com/cabal-club/cabal-core/pull/103.