### PR TITLE
Upgrade cabal-core for faster installs (sodium-native)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "cabal-core": "^13.2.0",
+    "cabal-core": "^14.1.1",
     "collect-stream": "^1.2.1",
     "dat-dns": "^4.1.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
Quickens install times from several minutes to seconds on machines lacking prebuilt binaries.