### PR TITLE
getChannels: add onlyJoined param

### DIFF
--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -317,11 +317,12 @@ class CabalDetails extends EventEmitter {
    * @param {object} [opts]
    * @property {boolean} includeArchived - Determines whether to include archived channels or not. Defaults to false.
    * @property {boolean} includePM - Determines whether to include private message channels or not. Defaults to false.
+   * @property {boolean} onlyJoined - Determines whether to limit returned channels to only those that are joined or not. Defaults to false.
    * @returns {string[]} a list of all the channels in this cabal. Does not return channels with 0 members.
    */
   getChannels (opts) {
     if (!opts || typeof opts !== "object" || opts[Symbol.iterator]) { 
-      opts = { includeArchived: false, includePM: false } 
+      opts = { includeArchived: false, includePM: false, onlyJoined: false}
     }
     // sort regular channels and PMs separately, then concat them together (if including PM) before returning
     const sortedChannels = Object.keys(this.channels)
@@ -330,6 +331,7 @@ class CabalDetails extends EventEmitter {
         && this.channels[ch].members.size > 0 
         && (!this.channels[ch].isPrivate)
         && (opts.includeArchived || !this.channels[ch].archived)
+        && (!opts.onlyJoined || opts.onlyJoined && this.channels[ch].joined)
       )
       .sort()
     // get all PMs with non-hidden users && sort them

--- a/src/channel-details.js
+++ b/src/channel-details.js
@@ -220,6 +220,7 @@ class PMChannelDetails extends ChannelDetails {
     this.recipient = pubkey
     this.isPrivate = true
     this.topic = "private message with " + pubkey
+    this.joined = true
     this.members.add(this.recipientKey) // makes sure # members > 0 :)
   }
 


### PR DESCRIPTION
this patch expands the `cabal-details:getChannels` function with an additional parameter `onlyJoined`

from the docs:
```
 onlyJoined - Determines whether to limit returned channels to only those that are joined or not. Defaults to false.
```

used primarily by the cli client atm