### PR TITLE
Allow leaving private messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dat-dns": "^4.1.2",
     "debug": "^4.1.1",
     "hypercore-crypto": "^2.1.0",
+    "js-yaml": "^4.1.0",
     "level": "^6.0.1",
     "memdb": "^1.3.1",
     "mkdirp": "^1.0.4",

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -382,7 +382,7 @@ class CabalDetails extends EventEmitter {
    * Query if the passed in channel name is private or not
    * @returns{boolean} true if channel is private, false if not (or if it doesn't exist)
    */
-  isChannelPrivate(channel) {
+  isChannelPrivate (channel) {
     const details = this.channels[channel]
     if (!details) { return false }
     return details.isPrivate
@@ -392,7 +392,7 @@ class CabalDetails extends EventEmitter {
    * Join a private message channel if it is not already joined.
    * @param {string} channel the key of the PM to join
    */
-  joinPrivateMessage(channel) {
+  joinPrivateMessage (channel) {
     this.settings.joinedPrivateMessages.push(channel)
     this.settings.joinedPrivateMessages = Array.from(new Set(this.settings.joinedPrivateMessages)) // dedupe array entries
     this.client.writeCabalSettings(this.key, this.settings)
@@ -402,7 +402,7 @@ class CabalDetails extends EventEmitter {
    * Leave a private message channel if it has not already been left.
    * @param {string} channel the key of the PM to leave
    */
-  leavePrivateMessage(channel) {
+  leavePrivateMessage (channel) {
     if (this.settings.joinedPrivateMessages.includes(channel)) {
       // Remove the private message from the joined setting
       this.settings.joinedPrivateMessages = this.settings.joinedPrivateMessages.filter((pm) => pm !== channel)

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -119,7 +119,7 @@ class CabalDetails extends EventEmitter {
         channel = this.user.key === message.key ? channel : message.key
         const details = this.channels[channel]
         if (!details) { // incoming PM & no pm channel?! instantiate a pm channel asap!
-          this.channels[channel] = new PMChannelDetails(this.core, channel)
+          this.channels[channel] = new PMChannelDetails(this, this.core, channel)
         }
         this._emitUpdate('private-message', {
           channel,
@@ -446,7 +446,7 @@ class CabalDetails extends EventEmitter {
     // check to see if we have opened a pm with this person before
     if (!pmInstance) {
       // if not: add a new PMChannelDetails instance to channels
-      this.channels[recipientKey] = new PMChannelDetails(this.core, recipientKey) 
+      this.channels[recipientKey] = new PMChannelDetails(this, this.core, recipientKey)
       // focus it
       this.focusChannel(recipientKey)
     } else if (!pmInstance.isPrivate) { // pm channel is not an actual pm instance! this should probably never happen, though

--- a/src/cabal-details.js
+++ b/src/cabal-details.js
@@ -93,6 +93,7 @@ class CabalDetails extends EventEmitter {
     this.users = {} // public keys -> cabal-core use
     this.listeners = [] // keep track of listeners so we can remove them when we remove a cabal
     this.user = undefined
+    this.settings = client.getCabalSettings(this.key)
     this._initialize(done)
   }
 
@@ -385,6 +386,28 @@ class CabalDetails extends EventEmitter {
     const details = this.channels[channel]
     if (!details) { return false }
     return details.isPrivate
+  }
+
+  /**
+   * Join a private message channel if it is not already joined.
+   * @param {string} channel the key of the PM to join
+   */
+  joinPrivateMessage(channel) {
+    this.settings.joinedPrivateMessages.push(channel)
+    this.settings.joinedPrivateMessages = Array.from(new Set(this.settings.joinedPrivateMessages)) // dedupe array entries
+    this.client.writeCabalSettings(this.key, this.settings)
+  }
+
+  /**
+   * Leave a private message channel if it has not already been left.
+   * @param {string} channel the key of the PM to leave
+   */
+  leavePrivateMessage(channel) {
+    if (this.settings.joinedPrivateMessages.includes(channel)) {
+      // Remove the private message from the joined setting
+      this.settings.joinedPrivateMessages = this.settings.joinedPrivateMessages.filter((pm) => pm !== channel)
+    }
+    this.client.writeCabalSettings(this.key, this.settings)
   }
 
   // redirects private messages posted via cabalDetails.publishMessage()

--- a/src/channel-details.js
+++ b/src/channel-details.js
@@ -213,14 +213,18 @@ class VirtualChannelDetails extends ChannelDetailsBase {
 }
 
 class PMChannelDetails extends ChannelDetails {
-  constructor (cabal, pubkey) {
+  constructor (details, cabal, pubkey) {
     super(cabal, pubkey)
     // change cabal api we read from to be private messages (not messages api)
     this.messages = cabal.privateMessages
     this.recipient = pubkey
     this.isPrivate = true
     this.topic = "private message with " + pubkey
-    this.joined = true
+    Object.defineProperty(this, 'joined', {
+      get: function() {
+        return details.settings.joinedPrivateMessages.includes(pubkey)
+      }
+    })
     this.members.add(this.recipientKey) // makes sure # members > 0 :)
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -132,7 +132,7 @@ class Client {
    * If the file doesn't exist, return {}.
    * @returns {object} the contents of the settings file
    */
-  readCabalSettingsFile() {
+  readCabalSettingsFile () {
     var settingsFilePath = Client.getCabalSettingsFile()
     if (fs.existsSync(settingsFilePath)) {
       return yaml.load(fs.readFileSync(settingsFilePath, 'utf8'))

--- a/src/initialization-callbacks.js
+++ b/src/initialization-callbacks.js
@@ -50,7 +50,7 @@ module.exports.getOpenedPMs = function (err, privates) {
   privates.forEach((pubkey) => {
     const details = this.channels[pubkey]
     if (!details) {
-      this.channels[pubkey] = new PMChannelDetails(cabal, pubkey)
+      this.channels[pubkey] = new PMChannelDetails(this, cabal, pubkey)
     }
   })
   this._finish()


### PR DESCRIPTION
The `/leave` command is now permitted on private messages.

A `settings.yml` file is now created in the `~/.cabal/` directory. Right now it looks like this:
```
{cabal id}:
  joinedPrivateMessages:
    - {pm id}
    - {pm id}
```
Private messages are now only considered "joined" if they are present in the list in the settings file for the cabal. New PMs or `/join`ing an old PM will add the PM id to the list, while `/leave` will remove it.