### PR TITLE
Handles case of being unable to resolve a key.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -248,7 +248,7 @@ class Client {
         const scrubbedKey = Client.scrubKey(resolvedKey)
 
         //  verify that scrubbedKey is 64 ch hex string
-        if (resolvedKey === null || !Cabal.isHypercoreKey(scrubbedKey)) {
+        if (scrubbedKey === '' || !Cabal.isHypercoreKey(scrubbedKey)) {
           dnsFailed = true
           return
         }

--- a/src/client.js
+++ b/src/client.js
@@ -104,6 +104,7 @@ class Client {
    * // => '12345678...'
    */
   static scrubKey (key) {
+      if (!key || typeof key !== 'string') return ''
       // remove url search params; indexOf returns -1 if no params => would chop off the last character if used w/ slice
       if (key.indexOf("?") >= 0) { 
           return key.slice(0, key.indexOf("?")).replace('cabal://', '').replace('cbl://', '').replace('dat://', '').replace(/\//g, '')
@@ -298,6 +299,9 @@ class Client {
             resolve(details)
           }
         })
+      }, err => {
+        cb(err)
+        reject(err)
       })
     })
   }

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,29 @@ test('create a cabal', function (t) {
     })
 })
 
+test.only('try to join an unknown cabal by name', function (t) {
+  t.plan(2)
+
+  const dir = tmp.dirSync().name
+  const client = new Client({
+    config: {
+      dbdir: dir
+    }
+  })
+  const opts = { noSwarm: true }
+  const garbageKey = "buzzlebopp"
+
+  client.addCabal(garbageKey, opts, (err, res) => {
+    t.ok(err)
+  })
+    .then((cabal) => {
+      t.fail('should have failed')
+    })
+    .catch(err => {
+      t.ok(err)
+    })
+})
+
 test('check that local user is admin', function (t) {
   t.plan(6)
 


### PR DESCRIPTION
The `addCabal` function wasn't previously propagating name resolution errors, causing cabal-cli to crash when invoked with a bad cabal name, like `cabal ewoijffwejlkw`.